### PR TITLE
WILF-020: open 0.1.7 development cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.1.6"
+version = "0.1.7.dev0"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Opens the development cycle after the immutable v0.1.6 baseline by setting the package version to 0.1.7.dev0.

This keeps CI artifacts from post-0.1.6 development clearly distinct from the published v0.1.6 release.