### PR TITLE
WILF-010: expose native capabilities through CLI

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -54,3 +54,16 @@ The first built-in READ capabilities are:
 Native capabilities are registered in `ToolRegistry` and executed through
 `ExecutionEngine`. They do not bypass validation, permissions or execution
 policy.
+
+### Native CLI capabilities
+
+Wilfred exposes its native READ capabilities through the same Tool
+Registry and Execution Engine used by registered tools.
+
+Commands:
+
+    wilfred status
+    wilfred tools
+
+Running `wilfred` without a subcommand preserves the existing
+standalone bootstrap behavior.

--- a/src/wilfred/__main__.py
+++ b/src/wilfred/__main__.py
@@ -13,6 +13,8 @@ from wilfred.config import (
     RuntimeConfig,
     load_config,
 )
+from wilfred.native import register_native_tools
+from wilfred.registry import ToolRegistry
 
 
 def runtime_status(
@@ -62,7 +64,50 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
 
+    commands = parser.add_subparsers(dest="command")
+
+    commands.add_parser(
+        "status",
+        help="Show Wilfred native runtime status.",
+    )
+    commands.add_parser(
+        "tools",
+        help="List Wilfred native capabilities.",
+    )
+
     return parser
+
+
+def run_native_command(command: str) -> int:
+    registry = ToolRegistry()
+    register_native_tools(registry)
+
+    tool_name = {
+        "status": "wilfred_status",
+        "tools": "wilfred_tools",
+    }[command]
+
+    result = registry.execute(tool_name)
+
+    if not result.ok:
+        print(
+            json.dumps(
+                result.to_dict(),
+                ensure_ascii=False,
+                sort_keys=True,
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        json.dumps(
+            result.value,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
 
 
 def main(
@@ -72,6 +117,9 @@ def main(
 ) -> int:
     parser = build_parser()
     arguments = parser.parse_args(argv)
+
+    if arguments.command is not None:
+        return run_native_command(arguments.command)
 
     try:
         config = load_config(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+import json
+
+from wilfred.__main__ import main
+
+
+def run_cli(arguments: list[str]) -> tuple[int, str, str]:
+    output = StringIO()
+    errors = StringIO()
+
+    with redirect_stdout(output), redirect_stderr(errors):
+        result = main(arguments, environ={})
+
+    return result, output.getvalue(), errors.getvalue()
+
+
+def test_status_command() -> None:
+    result, output, errors = run_cli(["status"])
+
+    assert result == 0
+    assert errors == ""
+
+    payload = json.loads(output)
+    assert payload["name"] == "Wilfred"
+    assert payload["status"] == "ok"
+    assert payload["runtime"] == "standalone"
+
+
+def test_tools_command() -> None:
+    result, output, errors = run_cli(["tools"])
+
+    assert result == 0
+    assert errors == ""
+
+    payload = json.loads(output)
+
+    assert [tool["name"] for tool in payload["tools"]] == [
+        "wilfred_status",
+        "wilfred_tools",
+    ]
+
+
+def test_no_command_preserves_existing_cli() -> None:
+    result, output, errors = run_cli([])
+
+    assert result == 0
+    assert errors == ""
+
+    payload = json.loads(output)
+    assert payload["runtime"] == "standalone-bootstrap"


### PR DESCRIPTION
Completes the CLI surface for Wilfred native capabilities.

- adds `wilfred status`
- adds `wilfred tools`
- routes both commands through Tool Registry and Execution Engine
- preserves the existing no-command bootstrap behavior
- adds CLI tests and development documentation

Validated locally: 56 tests passing.