### PR TITLE
WILF-021: automate GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,128 @@
+name: Wilfred Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout tagged revision
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Verify release contract
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="$GITHUB_REF_NAME"
+
+          if [[ ! "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "Invalid release tag: $TAG"
+            exit 1
+          fi
+
+          VERSION="${BASH_REMATCH[1]}"
+
+          PACKAGE_VERSION="$(
+            python - <<'PY'
+          import tomllib
+          from pathlib import Path
+
+          data = tomllib.loads(
+              Path("pyproject.toml").read_text(encoding="utf-8")
+          )
+          print(data["project"]["version"])
+          PY
+          )"
+
+          echo "Tag version:     $VERSION"
+          echo "Package version: $PACKAGE_VERSION"
+
+          test "$PACKAGE_VERSION" = "$VERSION"
+
+          git fetch origin main:refs/remotes/origin/main
+          git merge-base --is-ancestor HEAD origin/main
+
+          echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install build
+          python -m pip install -e ".[dev]"
+
+      - name: Compile and test
+        run: |
+          python -m compileall -q src tests
+          pytest -q
+
+      - name: Build distributions
+        run: |
+          python -m build
+          ls -lh dist/
+          test -n "$(find dist -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
+
+      - name: Verify clean-room wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python -m venv /tmp/wilfred-release-test
+          source /tmp/wilfred-release-test/bin/activate
+
+          python -m pip install --upgrade pip
+          python -m pip install dist/*.whl
+
+          python - <<'PY'
+          import os
+          from importlib.metadata import version
+          import wilfred
+
+          expected = os.environ["RELEASE_VERSION"]
+          metadata = version("wilfred-butler")
+
+          print("Expected:", expected)
+          print("Metadata:", metadata)
+          print("Runtime: ", wilfred.__version__)
+
+          assert metadata == expected
+          assert wilfred.__version__ == expected
+          PY
+
+          python -m pip check
+          wilfred --help
+          wilfred status
+          wilfred tools
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            dist/*.whl \
+            dist/*.tar.gz \
+            --verify-tag \
+            --title "Wilfred $GITHUB_REF_NAME" \
+            --generate-notes

--- a/docs/development.md
+++ b/docs/development.md
@@ -67,3 +67,18 @@ Commands:
 
 Running `wilfred` without a subcommand preserves the existing
 standalone bootstrap behavior.
+
+### Automated releases
+
+Stable Wilfred releases are published from immutable semantic-version
+tags such as `v0.1.7`.
+
+The release workflow verifies that the tag and package version match,
+that the tagged commit belongs to `main`, and that the public test
+suite passes. It then builds wheel and source distributions, verifies
+the wheel in a clean virtual environment, checks package dependencies
+and CLI entry points, and finally publishes the artifacts as a GitHub
+Release.
+
+Development versions such as `0.1.7.dev0` therefore cannot be
+published using a stable `v0.1.7` tag.

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+
+WORKFLOW = Path(".github/workflows/release.yml")
+
+
+def test_release_workflow_exists() -> None:
+    assert WORKFLOW.is_file()
+
+
+def test_release_workflow_guards_release_contract() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    required = [
+        'tags:',
+        '"v*.*.*"',
+        "contents: write",
+        'test "$PACKAGE_VERSION" = "$VERSION"',
+        "git merge-base --is-ancestor HEAD origin/main",
+        "pytest -q",
+        "python -m build",
+        "python -m pip check",
+        "wilfred status",
+        "wilfred tools",
+        "gh release create",
+        "dist/*.whl",
+        "dist/*.tar.gz",
+    ]
+
+    for marker in required:
+        assert marker in text
+
+
+def test_release_workflow_has_no_fixed_release_version() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "0.1.7.dev0" not in text
+    assert 'RELEASE_VERSION="0.' not in text


### PR DESCRIPTION
Adds the Wilfred tagged-release pipeline.

The workflow validates tag/package version consistency and main ancestry, runs the public test suite, builds wheel and sdist, verifies the installed wheel in a clean environment, checks CLI and dependencies, then publishes the GitHub Release.

WILF-021 remains in progress until the first real automated release proves the complete pipeline.