### PR TITLE
WILF-021: prepare Wilfred 0.1.7 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.1.7.dev0"
+version = "0.1.7"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Promotes the development version from 0.1.7.dev0 to the stable 0.1.7 package version.

Validated locally with 59 passing tests.

After merge, tag v0.1.7 will exercise the automated release workflow end-to-end. WILF-021 remains in progress until that release is published successfully.