### PR TITLE
WILF-022: add verified workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It provides:
 - typed tool definitions and permission levels;
 - a deterministic tool registry;
 - a structured Execution Engine with validation, policy and timeouts;
+- provider-agnostic READ-ACTION-VERIFY workflows;
 - a public plugin contract and loader;
 - a standalone command-line entrypoint;
 - an example read-only plugin;
@@ -53,6 +54,9 @@ variables, command-line overrides, validation and precedence.
 See [Execution Engine](docs/execution-engine.md) for argument validation,
 permissions, confirmations, timeouts and structured results.
 
+See [Verified workflows](docs/verified-workflows.md) for
+provider-agnostic READ-ACTION-VERIFY execution and verification.
+
 ## Current development status
 
 Wilfred currently provides:
@@ -62,13 +66,13 @@ Wilfred currently provides:
 - public tool and plugin contracts;
 - deterministic plugin loading;
 - a native Execution Engine;
+- provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification without Alfred or another consumer.
 
 The following capabilities are still under development and are not presented
 as available:
 
 - native Butler capabilities;
-- READ-ACTION-VERIFY workflows;
 - local persistence;
 - goal-oriented CLI and API;
 - the public Home Assistant adapter;

--- a/docs/execution-engine.md
+++ b/docs/execution-engine.md
@@ -82,10 +82,13 @@ must remain bounded and cooperative.
 
 ## Current boundary
 
-The Execution Engine is infrastructure, not yet a complete autonomous Butler.
+The Execution Engine remains the single-tool execution layer.
 
-Native capabilities, READ-ACTION-VERIFY workflows, persistence, goal APIs,
-Home Assistant integration and the Wilfred `0.2.0` public alpha are still
-under development.
+Provider-agnostic READ-ACTION-VERIFY workflows build on it without
+redefining Execution Engine `success` as proof of external state change.
+See [Verified workflows](verified-workflows.md).
+
+Native capabilities, persistence, goal APIs, Home Assistant integration
+and the Wilfred `0.2.0` public alpha are still under development.
 
 The crowdfunding campaign has not launched.

--- a/docs/verified-workflows.md
+++ b/docs/verified-workflows.md
@@ -1,0 +1,62 @@
+# Verified workflows
+
+Wilfred provides a provider-agnostic READ-ACTION-VERIFY workflow for actions
+whose external outcome must be checked after dispatch.
+
+The workflow builds on the Execution Engine rather than replacing it.
+
+An Execution Engine `success` means that a tool handler completed
+successfully. It does not prove that the requested external or physical state
+was reached.
+
+A verified workflow performs:
+
+1. a READ of the initial state;
+2. an ACTION through the Execution Engine;
+3. a second READ of observable state;
+4. verification over the three returned values.
+
+## Verification statuses
+
+The workflow returns:
+
+- `verified`: the verifier returned `True`;
+- `failed`: the action failed or verification returned `False`;
+- `indeterminate`: Wilfred cannot establish the outcome reliably.
+
+A failed initial READ stops execution before ACTION.
+
+A failed post-action READ leaves a successful dispatch unverified and returns
+`indeterminate`.
+
+## Permission boundary
+
+Both observation steps must use `READ` tools.
+
+The action step must use an `ACTION` or `DANGEROUS` tool. Normal Execution
+Engine policy still applies, including confirmations and dangerous-tool
+policy.
+
+The workflow validates this structure before executing any step.
+
+## Verifier contract
+
+The verifier receives:
+
+- the value returned by READ-before;
+- the value returned by ACTION;
+- the value returned by READ-after.
+
+It must return `True`, `False` or `None`.
+
+`None` means the observations are insufficient to determine the outcome.
+
+## Current boundary
+
+This first workflow is synchronous and intentionally small.
+
+It does not yet provide persistence, retries, delayed verification, recovery
+or Home Assistant-specific behaviour.
+
+Automatic ACTION retries are deliberately outside this contract because
+repeating an external or physical action may be unsafe or non-idempotent.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.1.7"
+version = "0.1.8.dev0"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/wilfred/__init__.py
+++ b/src/wilfred/__init__.py
@@ -37,6 +37,12 @@ from wilfred.plugins import (
     load_plugins,
 )
 from wilfred.registry import ToolRegistry
+from wilfred.workflows import (
+    ReadActionVerifyRequest,
+    ReadActionVerifyResult,
+    ReadActionVerifyWorkflow,
+    VerificationStatus,
+)
 
 
 try:
@@ -61,10 +67,14 @@ __all__ = [
     "OutputRequest",
     "PluginDefinition",
     "PluginLoadResult",
+    "ReadActionVerifyRequest",
+    "ReadActionVerifyResult",
+    "ReadActionVerifyWorkflow",
     "RuntimeConfig",
     "ToolDefinition",
     "ToolPermission",
     "ToolRegistry",
+    "VerificationStatus",
     "discover_plugins",
     "load_config",
     "load_plugin",

--- a/src/wilfred/workflows.py
+++ b/src/wilfred/workflows.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from time import monotonic_ns
+from typing import Any
+from uuid import uuid4
+
+from wilfred.execution import (
+    ExecutionEngine,
+    ExecutionPolicy,
+    ExecutionRequest,
+    ExecutionResult,
+)
+from wilfred.models import ToolPermission
+from wilfred.registry import ToolRegistry
+
+
+Verifier = Callable[[Any, Any, Any], bool | None]
+
+
+class VerificationStatus(str, Enum):
+    VERIFIED = "verified"
+    FAILED = "failed"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True)
+class ReadActionVerifyRequest:
+    read_before: ExecutionRequest
+    action: ExecutionRequest
+    read_after: ExecutionRequest
+    verifier: Verifier
+    workflow_id: str = field(
+        default_factory=lambda: str(uuid4())
+    )
+
+
+@dataclass(frozen=True)
+class ReadActionVerifyResult:
+    workflow_id: str
+    status: VerificationStatus
+    duration_ms: float
+    read_before: ExecutionResult | None = None
+    action: ExecutionResult | None = None
+    read_after: ExecutionResult | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status is VerificationStatus.VERIFIED
+
+    def to_dict(self) -> dict[str, Any]:
+        error = None
+        if self.error_code is not None:
+            error = {
+                "code": self.error_code,
+                "message": self.error_message,
+            }
+
+        return {
+            "workflow_id": self.workflow_id,
+            "status": self.status.value,
+            "duration_ms": self.duration_ms,
+            "read_before": (
+                self.read_before.to_dict()
+                if self.read_before is not None
+                else None
+            ),
+            "action": (
+                self.action.to_dict()
+                if self.action is not None
+                else None
+            ),
+            "read_after": (
+                self.read_after.to_dict()
+                if self.read_after is not None
+                else None
+            ),
+            "error": error,
+        }
+
+
+class ReadActionVerifyWorkflow:
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        *,
+        policy: ExecutionPolicy | None = None,
+    ) -> None:
+        self._registry = registry
+        self._engine = ExecutionEngine(
+            registry,
+            policy=policy,
+        )
+
+    def execute(
+        self,
+        request: ReadActionVerifyRequest,
+    ) -> ReadActionVerifyResult:
+        started = monotonic_ns()
+
+        error = self._validate_contract(request)
+        if error is not None:
+            return self._result(
+                request,
+                started,
+                VerificationStatus.FAILED,
+                error_code=error[0],
+                error_message=error[1],
+            )
+
+        before = self._engine.execute(request.read_before)
+        if not before.ok:
+            return self._result(
+                request,
+                started,
+                VerificationStatus.INDETERMINATE,
+                read_before=before,
+                error_code="read_before_failed",
+                error_message="Initial READ failed.",
+            )
+
+        action = self._engine.execute(request.action)
+        if not action.ok:
+            return self._result(
+                request,
+                started,
+                VerificationStatus.FAILED,
+                read_before=before,
+                action=action,
+                error_code="action_failed",
+                error_message="ACTION did not complete.",
+            )
+
+        after = self._engine.execute(request.read_after)
+        if not after.ok:
+            return self._result(
+                request,
+                started,
+                VerificationStatus.INDETERMINATE,
+                read_before=before,
+                action=action,
+                read_after=after,
+                error_code="read_after_failed",
+                error_message="Post-action READ failed.",
+            )
+
+        try:
+            decision = request.verifier(
+                before.value,
+                action.value,
+                after.value,
+            )
+        except Exception as exc:
+            return self._result(
+                request,
+                started,
+                VerificationStatus.INDETERMINATE,
+                read_before=before,
+                action=action,
+                read_after=after,
+                error_code="verification_error",
+                error_message=f"{type(exc).__name__}: {exc}",
+            )
+
+        if decision is True:
+            status = VerificationStatus.VERIFIED
+            code = None
+            message = None
+        elif decision is False:
+            status = VerificationStatus.FAILED
+            code = "verification_failed"
+            message = "Observed state did not satisfy verifier."
+        elif decision is None:
+            status = VerificationStatus.INDETERMINATE
+            code = "verification_indeterminate"
+            message = "Verifier could not determine outcome."
+        else:
+            status = VerificationStatus.INDETERMINATE
+            code = "invalid_verifier_result"
+            message = "Verifier must return True, False or None."
+
+        return self._result(
+            request,
+            started,
+            status,
+            read_before=before,
+            action=action,
+            read_after=after,
+            error_code=code,
+            error_message=message,
+        )
+
+    def _validate_contract(
+        self,
+        request: ReadActionVerifyRequest,
+    ) -> tuple[str, str] | None:
+        for name, step in (
+            ("read_before", request.read_before),
+            ("read_after", request.read_after),
+        ):
+            tool = self._registry.get(step.tool_name)
+            if tool is None:
+                return (
+                    "tool_not_found",
+                    f"{name} tool not registered: {step.tool_name}",
+                )
+
+            if tool.permission is not ToolPermission.READ:
+                return (
+                    "invalid_read_tool",
+                    f"{name} must use a READ tool.",
+                )
+
+        tool = self._registry.get(request.action.tool_name)
+        if tool is None:
+            return (
+                "tool_not_found",
+                (
+                    "action tool not registered: "
+                    f"{request.action.tool_name}"
+                ),
+            )
+
+        if tool.permission not in {
+            ToolPermission.ACTION,
+            ToolPermission.DANGEROUS,
+        }:
+            return (
+                "invalid_action_tool",
+                "action must use ACTION or DANGEROUS tool.",
+            )
+
+        return None
+
+    @staticmethod
+    def _result(
+        request: ReadActionVerifyRequest,
+        started: int,
+        status: VerificationStatus,
+        *,
+        read_before: ExecutionResult | None = None,
+        action: ExecutionResult | None = None,
+        read_after: ExecutionResult | None = None,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> ReadActionVerifyResult:
+        elapsed = (monotonic_ns() - started) / 1_000_000
+
+        return ReadActionVerifyResult(
+            workflow_id=request.workflow_id,
+            status=status,
+            duration_ms=round(max(elapsed, 0.0), 3),
+            read_before=read_before,
+            action=action,
+            read_after=read_after,
+            error_code=error_code,
+            error_message=error_message,
+        )

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -101,5 +101,33 @@ class WilfredDocumentationTests(unittest.TestCase):
         )
 
 
+
+    def test_verified_workflow_guide_documents_contract(self) -> None:
+        guide = (
+            PROJECT_ROOT
+            / "docs"
+            / "verified-workflows.md"
+        ).read_text(encoding="utf-8")
+
+        normalized = " ".join(guide.split())
+
+        for status in (
+            "verified",
+            "failed",
+            "indeterminate",
+        ):
+            self.assertIn(status, guide)
+
+        self.assertIn(
+            "It does not prove that the requested external "
+            "or physical state was reached.",
+            normalized,
+        )
+        self.assertIn(
+            "Automatic ACTION retries are deliberately outside",
+            normalized,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,312 @@
+from __future__ import annotations
+
+from wilfred.execution import (
+    ExecutionRequest,
+    ExecutionStatus,
+)
+from wilfred.models import (
+    ToolDefinition,
+    ToolPermission,
+)
+from wilfred.registry import ToolRegistry
+from wilfred.workflows import (
+    ReadActionVerifyRequest,
+    ReadActionVerifyWorkflow,
+    VerificationStatus,
+)
+
+
+def register(
+    registry: ToolRegistry,
+    name: str,
+    handler,
+    permission: ToolPermission,
+) -> None:
+    registry.register(
+        ToolDefinition(
+            name=name,
+            description=f"Test tool: {name}",
+            handler=handler,
+            permission=permission,
+        )
+    )
+
+
+def request() -> ReadActionVerifyRequest:
+    return ReadActionVerifyRequest(
+        read_before=ExecutionRequest(
+            tool_name="read_state",
+        ),
+        action=ExecutionRequest(
+            tool_name="action",
+            confirmed=True,
+        ),
+        read_after=ExecutionRequest(
+            tool_name="read_state",
+        ),
+        verifier=lambda before, _action, after: (
+            before["power"] == "off"
+            and after["power"] == "on"
+        ),
+    )
+
+
+def test_verified_after_real_state_change() -> None:
+    state = {"power": "off"}
+    registry = ToolRegistry()
+
+    register(
+        registry,
+        "read_state",
+        lambda: dict(state),
+        ToolPermission.READ,
+    )
+
+    def turn_on():
+        state["power"] = "on"
+        return {"accepted": True}
+
+    register(
+        registry,
+        "action",
+        turn_on,
+        ToolPermission.ACTION,
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(request())
+
+    assert result.ok
+    assert result.status is VerificationStatus.VERIFIED
+    assert result.action is not None
+    assert result.action.ok
+    assert result.read_after is not None
+    assert result.read_after.value["power"] == "on"
+
+
+def test_dispatch_success_is_not_verification() -> None:
+    state = {"power": "off"}
+    registry = ToolRegistry()
+
+    register(
+        registry,
+        "read_state",
+        lambda: dict(state),
+        ToolPermission.READ,
+    )
+
+    register(
+        registry,
+        "action",
+        lambda: {"accepted": True},
+        ToolPermission.ACTION,
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(request())
+
+    assert not result.ok
+    assert result.status is VerificationStatus.FAILED
+    assert result.action is not None
+    assert result.action.ok
+    assert result.error_code == "verification_failed"
+
+
+def test_failed_initial_read_prevents_action() -> None:
+    calls = {"action": 0}
+    registry = ToolRegistry()
+
+    def broken_read():
+        raise RuntimeError("sensor unavailable")
+
+    def action():
+        calls["action"] += 1
+
+    register(
+        registry,
+        "read_state",
+        broken_read,
+        ToolPermission.READ,
+    )
+    register(
+        registry,
+        "action",
+        action,
+        ToolPermission.ACTION,
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(request())
+
+    assert result.status is VerificationStatus.INDETERMINATE
+    assert result.error_code == "read_before_failed"
+    assert result.action is None
+    assert calls["action"] == 0
+
+
+def test_failed_action_prevents_post_read() -> None:
+    reads = {"count": 0}
+    registry = ToolRegistry()
+
+    def read_state():
+        reads["count"] += 1
+        return {"power": "off"}
+
+    def broken_action():
+        raise RuntimeError("dispatch failed")
+
+    register(
+        registry,
+        "read_state",
+        read_state,
+        ToolPermission.READ,
+    )
+    register(
+        registry,
+        "action",
+        broken_action,
+        ToolPermission.ACTION,
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(request())
+
+    assert result.status is VerificationStatus.FAILED
+    assert result.error_code == "action_failed"
+    assert result.action is not None
+    assert result.action.status is ExecutionStatus.ERROR
+    assert result.read_after is None
+    assert reads["count"] == 1
+
+
+def test_failed_post_read_is_indeterminate() -> None:
+    reads = {"count": 0}
+    registry = ToolRegistry()
+
+    def read_state():
+        reads["count"] += 1
+        if reads["count"] == 2:
+            raise RuntimeError("sensor unavailable")
+        return {"power": "off"}
+
+    register(
+        registry,
+        "read_state",
+        read_state,
+        ToolPermission.READ,
+    )
+    register(
+        registry,
+        "action",
+        lambda: {"accepted": True},
+        ToolPermission.ACTION,
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(request())
+
+    assert result.status is VerificationStatus.INDETERMINATE
+    assert result.error_code == "read_after_failed"
+    assert result.action is not None
+    assert result.action.ok
+    assert result.read_after is not None
+    assert result.read_after.status is ExecutionStatus.ERROR
+
+
+def test_action_tool_cannot_be_used_as_read() -> None:
+    calls = {"bad_read": 0}
+    registry = ToolRegistry()
+
+    def bad_read():
+        calls["bad_read"] += 1
+        return {"power": "off"}
+
+    register(
+        registry,
+        "read_state",
+        bad_read,
+        ToolPermission.ACTION,
+    )
+    register(
+        registry,
+        "action",
+        lambda: None,
+        ToolPermission.ACTION,
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(request())
+
+    assert result.status is VerificationStatus.FAILED
+    assert result.error_code == "invalid_read_tool"
+    assert calls["bad_read"] == 0
+
+
+def test_verifier_can_report_indeterminate() -> None:
+    registry = ToolRegistry()
+
+    register(
+        registry,
+        "read_state",
+        lambda: {"power": "off"},
+        ToolPermission.READ,
+    )
+    register(
+        registry,
+        "action",
+        lambda: {"accepted": True},
+        ToolPermission.ACTION,
+    )
+
+    workflow_request = request()
+    workflow_request = ReadActionVerifyRequest(
+        read_before=workflow_request.read_before,
+        action=workflow_request.action,
+        read_after=workflow_request.read_after,
+        verifier=lambda *_: None,
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(workflow_request)
+
+    assert result.status is VerificationStatus.INDETERMINATE
+    assert result.error_code == "verification_indeterminate"
+
+
+def test_invalid_verifier_result_is_indeterminate() -> None:
+    registry = ToolRegistry()
+
+    register(
+        registry,
+        "read_state",
+        lambda: {"power": "off"},
+        ToolPermission.READ,
+    )
+    register(
+        registry,
+        "action",
+        lambda: {"accepted": True},
+        ToolPermission.ACTION,
+    )
+
+    workflow_request = request()
+    workflow_request = ReadActionVerifyRequest(
+        read_before=workflow_request.read_before,
+        action=workflow_request.action,
+        read_after=workflow_request.read_after,
+        verifier=lambda *_: "yes",
+    )
+
+    result = ReadActionVerifyWorkflow(
+        registry
+    ).execute(workflow_request)
+
+    assert result.status is VerificationStatus.INDETERMINATE
+    assert result.error_code == "invalid_verifier_result"


### PR DESCRIPTION
## Summary

Adds the first provider-agnostic verified workflow contract for Wilfred.

The workflow performs:

- READ before action
- ACTION through the existing Execution Engine
- READ after action
- explicit verification of the observed outcome

Execution Engine success continues to mean that the tool handler completed.
It does not mean that the requested external or physical state was reached.

## Verification outcomes

- `verified`
- `failed`
- `indeterminate`

The workflow also enforces the permission boundary before execution:

- observation steps require `READ`
- action requires `ACTION` or `DANGEROUS`
- existing Execution Engine confirmation and policy rules remain authoritative

## Validation

Local checkout:

- 68 tests passed
- compileall passed
- wheel and sdist built successfully
- clean-room wheel installation passed
- public workflow API imported successfully
- package version: `0.1.8.dev0`

This opens the first functional slice of the Wilfred 0.1.8
"Verified workflows & persistence" development cycle.

Refs: WILF-022
