### PR TITLE
WILF-023: add workflow persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ It provides:
 - a deterministic tool registry;
 - a structured Execution Engine with validation, policy and timeouts;
 - provider-agnostic READ-ACTION-VERIFY workflows;
+- local SQLite persistence for completed workflow results;
 - a public plugin contract and loader;
 - a standalone command-line entrypoint;
 - an example read-only plugin;
@@ -57,6 +58,9 @@ permissions, confirmations, timeouts and structured results.
 See [Verified workflows](docs/verified-workflows.md) for
 provider-agnostic READ-ACTION-VERIFY execution and verification.
 
+See [Workflow persistence](docs/persistence.md) for the provider-neutral
+store contract and local SQLite implementation.
+
 ## Current development status
 
 Wilfred currently provides:
@@ -73,7 +77,6 @@ The following capabilities are still under development and are not presented
 as available:
 
 - native Butler capabilities;
-- local persistence;
 - goal-oriented CLI and API;
 - the public Home Assistant adapter;
 - the Wilfred `0.2.0` public alpha.

--- a/docs/execution-engine.md
+++ b/docs/execution-engine.md
@@ -88,7 +88,8 @@ Provider-agnostic READ-ACTION-VERIFY workflows build on it without
 redefining Execution Engine `success` as proof of external state change.
 See [Verified workflows](verified-workflows.md).
 
-Native capabilities, persistence, goal APIs, Home Assistant integration
-and the Wilfred `0.2.0` public alpha are still under development.
+Native capabilities, verified workflows and local workflow persistence are
+available. Goal APIs, Home Assistant integration and the Wilfred `0.2.0`
+public alpha are still under development.
 
 The crowdfunding campaign has not launched.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,0 +1,78 @@
+# Workflow persistence
+
+Wilfred provides a local SQLite store for completed verified workflow results.
+
+Persistence is deliberately separate from workflow execution.
+
+The workflow does not persist automatically.
+
+A workflow produces a `ReadActionVerifyResult`. The caller may then persist
+that completed result through `WorkflowStore`.
+
+A storage failure therefore does not redefine whether an action was
+dispatched or whether its external outcome was verified.
+
+## Public contract
+
+The persistence API provides:
+
+- `WorkflowStore`: provider-neutral storage protocol;
+- `SQLiteWorkflowStore`: local SQLite implementation;
+- `WorkflowRecord`: persisted result plus persistence timestamp;
+- `WorkflowPersistenceError`: persistence contract failure.
+
+The basic operations are:
+
+- `save(result)`;
+- `get(workflow_id)`;
+- `list_recent(limit=...)`.
+
+## Immutable workflow history
+
+A `workflow_id` identifies one completed workflow result.
+
+Saving the same result again is idempotent and returns the existing record.
+
+Attempting to save a different result with an already persisted
+`workflow_id` raises `WorkflowPersistenceError`.
+
+The SQLite implementation does not silently overwrite workflow history.
+
+## Serialization
+
+Workflow results are stored as JSON together with searchable record metadata.
+
+The complete structured `ReadActionVerifyResult` is reconstructed when read,
+including its READ-before, ACTION and READ-after execution results.
+
+Result values must therefore be JSON serializable.
+
+Invalid or corrupt stored payloads raise `WorkflowPersistenceError` rather
+than being returned as apparently valid workflow results.
+
+## SQLite lifecycle
+
+A filesystem database survives store recreation and process restarts.
+
+The special `:memory:` database is also supported. Wilfred keeps an anchor
+connection alive internally so operations on the same store share the same
+in-memory database.
+
+No third-party database dependency is required. The implementation uses
+Python's standard-library `sqlite3` module.
+
+## Current boundary
+
+Persistence stores completed workflow results only.
+
+It does not currently provide:
+
+- automatic persistence from workflow execution;
+- retries or delayed verification;
+- workflow resumption;
+- distributed locking;
+- retention policies;
+- Home Assistant-specific storage.
+
+These concerns can build on the persistence contract without making storage
+part of the Execution Engine.

--- a/docs/verified-workflows.md
+++ b/docs/verified-workflows.md
@@ -55,7 +55,10 @@ It must return `True`, `False` or `None`.
 
 This first workflow is synchronous and intentionally small.
 
-It does not yet provide persistence, retries, delayed verification, recovery
+Persistence is available as a separate optional storage layer. The workflow
+does not persist automatically. See [Workflow persistence](persistence.md).
+
+The workflow does not yet provide retries, delayed verification, recovery
 or Home Assistant-specific behaviour.
 
 Automatic ACTION retries are deliberately outside this contract because

--- a/src/wilfred/__init__.py
+++ b/src/wilfred/__init__.py
@@ -29,6 +29,12 @@ from wilfred.output import (
     OutputPriority,
     OutputRequest,
 )
+from wilfred.persistence import (
+    SQLiteWorkflowStore,
+    WorkflowPersistenceError,
+    WorkflowRecord,
+    WorkflowStore,
+)
 from wilfred.plugins import (
     PluginDefinition,
     PluginLoadResult,
@@ -71,10 +77,14 @@ __all__ = [
     "ReadActionVerifyResult",
     "ReadActionVerifyWorkflow",
     "RuntimeConfig",
+    "SQLiteWorkflowStore",
     "ToolDefinition",
     "ToolPermission",
     "ToolRegistry",
     "VerificationStatus",
+    "WorkflowPersistenceError",
+    "WorkflowRecord",
+    "WorkflowStore",
     "discover_plugins",
     "load_config",
     "load_plugin",

--- a/src/wilfred/persistence.py
+++ b/src/wilfred/persistence.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, Protocol
+from uuid import uuid4
+
+from wilfred.execution import (
+    ExecutionResult,
+    ExecutionStatus,
+)
+from wilfred.models import ToolPermission
+from wilfred.workflows import (
+    ReadActionVerifyResult,
+    VerificationStatus,
+)
+
+
+class WorkflowPersistenceError(RuntimeError):
+    """Raised when a workflow result cannot be persisted safely."""
+
+
+@dataclass(frozen=True)
+class WorkflowRecord:
+    workflow_id: str
+    persisted_at: str
+    result: ReadActionVerifyResult
+
+
+class WorkflowStore(Protocol):
+    def save(
+        self,
+        result: ReadActionVerifyResult,
+    ) -> WorkflowRecord:
+        ...
+
+    def get(
+        self,
+        workflow_id: str,
+    ) -> WorkflowRecord | None:
+        ...
+
+    def list_recent(
+        self,
+        *,
+        limit: int = 100,
+    ) -> tuple[WorkflowRecord, ...]:
+        ...
+
+
+class SQLiteWorkflowStore:
+    def __init__(
+        self,
+        database: str | Path,
+    ) -> None:
+        requested = str(database)
+        self._memory_anchor: sqlite3.Connection | None = None
+
+        if requested == ":memory:":
+            self._database = (
+                f"file:wilfred-workflows-{uuid4().hex}"
+                "?mode=memory&cache=shared"
+            )
+            self._use_uri = True
+            self._memory_anchor = self._new_connection()
+        else:
+            self._database = requested
+            self._use_uri = False
+
+        self._initialize()
+
+    def save(
+        self,
+        result: ReadActionVerifyResult,
+    ) -> WorkflowRecord:
+        payload = self._serialize(result)
+
+        with self._connect() as connection:
+            existing = connection.execute(
+                """
+                SELECT persisted_at, payload_json
+                FROM workflow_results
+                WHERE workflow_id = ?
+                """,
+                (result.workflow_id,),
+            ).fetchone()
+
+            if existing is not None:
+                if existing["payload_json"] != payload:
+                    raise WorkflowPersistenceError(
+                        "workflow_id already exists with "
+                        "a different result."
+                    )
+
+                return WorkflowRecord(
+                    workflow_id=result.workflow_id,
+                    persisted_at=existing["persisted_at"],
+                    result=result,
+                )
+
+            persisted_at = datetime.now(
+                timezone.utc
+            ).isoformat()
+
+            connection.execute(
+                """
+                INSERT INTO workflow_results (
+                    workflow_id,
+                    status,
+                    persisted_at,
+                    payload_json
+                )
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    result.workflow_id,
+                    result.status.value,
+                    persisted_at,
+                    payload,
+                ),
+            )
+
+        return WorkflowRecord(
+            workflow_id=result.workflow_id,
+            persisted_at=persisted_at,
+            result=result,
+        )
+
+    def get(
+        self,
+        workflow_id: str,
+    ) -> WorkflowRecord | None:
+        with self._connect() as connection:
+            row = connection.execute(
+                """
+                SELECT workflow_id, persisted_at, payload_json
+                FROM workflow_results
+                WHERE workflow_id = ?
+                """,
+                (workflow_id,),
+            ).fetchone()
+
+        if row is None:
+            return None
+
+        return WorkflowRecord(
+            workflow_id=row["workflow_id"],
+            persisted_at=row["persisted_at"],
+            result=self._deserialize(row["payload_json"]),
+        )
+
+    def list_recent(
+        self,
+        *,
+        limit: int = 100,
+    ) -> tuple[WorkflowRecord, ...]:
+        if limit < 1:
+            raise ValueError("limit must be at least 1.")
+
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT workflow_id, persisted_at, payload_json
+                FROM workflow_results
+                ORDER BY persisted_at DESC, rowid DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+
+        return tuple(
+            WorkflowRecord(
+                workflow_id=row["workflow_id"],
+                persisted_at=row["persisted_at"],
+                result=self._deserialize(
+                    row["payload_json"]
+                ),
+            )
+            for row in rows
+        )
+
+    def _initialize(self) -> None:
+        if not self._use_uri:
+            Path(self._database).parent.mkdir(
+                parents=True,
+                exist_ok=True,
+            )
+
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS workflow_results (
+                    workflow_id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    persisted_at TEXT NOT NULL,
+                    payload_json TEXT NOT NULL
+                )
+                """
+            )
+            connection.execute(
+                """
+                CREATE INDEX IF NOT EXISTS
+                    idx_workflow_results_persisted_at
+                ON workflow_results (persisted_at DESC)
+                """
+            )
+
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
+        connection = self._new_connection()
+        try:
+            with connection:
+                yield connection
+        finally:
+            connection.close()
+
+    def _new_connection(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(
+            self._database,
+            uri=self._use_uri,
+        )
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    @staticmethod
+    def _serialize(
+        result: ReadActionVerifyResult,
+    ) -> str:
+        try:
+            return json.dumps(
+                result.to_dict(),
+                ensure_ascii=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+        except (TypeError, ValueError) as exc:
+            raise WorkflowPersistenceError(
+                "Workflow result is not JSON serializable."
+            ) from exc
+
+    @staticmethod
+    def _deserialize(
+        payload: str,
+    ) -> ReadActionVerifyResult:
+        try:
+            data = json.loads(payload)
+            error = data.get("error")
+
+            return ReadActionVerifyResult(
+                workflow_id=data["workflow_id"],
+                status=VerificationStatus(
+                    data["status"]
+                ),
+                duration_ms=float(data["duration_ms"]),
+                read_before=_execution_result(
+                    data.get("read_before")
+                ),
+                action=_execution_result(
+                    data.get("action")
+                ),
+                read_after=_execution_result(
+                    data.get("read_after")
+                ),
+                error_code=(
+                    error.get("code")
+                    if error is not None
+                    else None
+                ),
+                error_message=(
+                    error.get("message")
+                    if error is not None
+                    else None
+                ),
+            )
+        except (
+            json.JSONDecodeError,
+            KeyError,
+            TypeError,
+            ValueError,
+        ) as exc:
+            raise WorkflowPersistenceError(
+                "Stored workflow result is invalid."
+            ) from exc
+
+
+def _execution_result(
+    data: dict | None,
+) -> ExecutionResult | None:
+    if data is None:
+        return None
+
+    error = data.get("error")
+    permission = data.get("permission")
+
+    return ExecutionResult(
+        execution_id=data["execution_id"],
+        tool_name=data["tool_name"],
+        status=ExecutionStatus(data["status"]),
+        duration_ms=float(data["duration_ms"]),
+        permission=(
+            ToolPermission(permission)
+            if permission is not None
+            else None
+        ),
+        value=data.get("value"),
+        error_code=(
+            error.get("code")
+            if error is not None
+            else None
+        ),
+        error_message=(
+            error.get("message")
+            if error is not None
+            else None
+        ),
+        validation_errors=tuple(
+            data.get("validation_errors", ())
+        ),
+    )

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -129,5 +129,37 @@ class WilfredDocumentationTests(unittest.TestCase):
         )
 
 
+
+    def test_persistence_guide_documents_contract(self) -> None:
+        guide = (
+            PROJECT_ROOT
+            / "docs"
+            / "persistence.md"
+        ).read_text(encoding="utf-8")
+
+        normalized = " ".join(guide.split())
+
+        for term in (
+            "WorkflowStore",
+            "SQLiteWorkflowStore",
+            "WorkflowRecord",
+            "WorkflowPersistenceError",
+        ):
+            self.assertIn(term, guide)
+
+        self.assertIn(
+            "Persistence is deliberately separate from workflow execution.",
+            normalized,
+        )
+        self.assertIn(
+            "does not silently overwrite workflow history",
+            normalized,
+        )
+        self.assertIn(
+            "does not persist automatically",
+            normalized,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from wilfred.execution import ExecutionRequest
+from wilfred.models import ToolDefinition, ToolPermission
+from wilfred.persistence import (
+    SQLiteWorkflowStore,
+    WorkflowPersistenceError,
+)
+from wilfred.registry import ToolRegistry
+from wilfred.workflows import (
+    ReadActionVerifyRequest,
+    ReadActionVerifyWorkflow,
+    VerificationStatus,
+)
+
+
+def make_result(
+    workflow_id: str,
+    *,
+    change_state: bool = True,
+    action_value=None,
+):
+    state = {"power": "off"}
+    registry = ToolRegistry()
+
+    registry.register(
+        ToolDefinition(
+            name="read_state",
+            description="Read test state.",
+            handler=lambda: dict(state),
+            permission=ToolPermission.READ,
+        )
+    )
+
+    def action():
+        if change_state:
+            state["power"] = "on"
+        if action_value is not None:
+            return action_value
+        return {"accepted": True}
+
+    registry.register(
+        ToolDefinition(
+            name="turn_on",
+            description="Change test state.",
+            handler=action,
+            permission=ToolPermission.ACTION,
+        )
+    )
+
+    request = ReadActionVerifyRequest(
+        workflow_id=workflow_id,
+        read_before=ExecutionRequest(
+            tool_name="read_state",
+        ),
+        action=ExecutionRequest(
+            tool_name="turn_on",
+            confirmed=True,
+        ),
+        read_after=ExecutionRequest(
+            tool_name="read_state",
+        ),
+        verifier=lambda _before, _action, after: (
+            after["power"] == "on"
+        ),
+    )
+
+    return ReadActionVerifyWorkflow(
+        registry
+    ).execute(request)
+
+
+def test_file_round_trip_survives_reopen(tmp_path) -> None:
+    database = tmp_path / "workflows.sqlite3"
+    result = make_result("wf-round-trip")
+
+    first = SQLiteWorkflowStore(database)
+    saved = first.save(result)
+
+    second = SQLiteWorkflowStore(database)
+    loaded = second.get("wf-round-trip")
+
+    assert loaded is not None
+    assert loaded.persisted_at == saved.persisted_at
+    assert loaded.result.workflow_id == result.workflow_id
+    assert loaded.result.status is VerificationStatus.VERIFIED
+    assert loaded.result.read_before is not None
+    assert loaded.result.action is not None
+    assert loaded.result.read_after is not None
+    assert loaded.result.read_before.value == {"power": "off"}
+    assert loaded.result.action.value == {"accepted": True}
+    assert loaded.result.read_after.value == {"power": "on"}
+
+
+def test_memory_store_survives_multiple_operations() -> None:
+    store = SQLiteWorkflowStore(":memory:")
+    result = make_result("wf-memory")
+
+    store.save(result)
+    loaded = store.get("wf-memory")
+
+    assert loaded is not None
+    assert loaded.result.status is VerificationStatus.VERIFIED
+    assert len(store.list_recent()) == 1
+
+
+def test_same_result_save_is_idempotent(tmp_path) -> None:
+    store = SQLiteWorkflowStore(
+        tmp_path / "workflows.sqlite3"
+    )
+    result = make_result("wf-idempotent")
+
+    first = store.save(result)
+    second = store.save(result)
+
+    assert second.persisted_at == first.persisted_at
+    assert len(store.list_recent()) == 1
+
+
+def test_same_workflow_id_cannot_be_rewritten(tmp_path) -> None:
+    store = SQLiteWorkflowStore(
+        tmp_path / "workflows.sqlite3"
+    )
+
+    verified = make_result(
+        "wf-collision",
+        change_state=True,
+    )
+    failed = make_result(
+        "wf-collision",
+        change_state=False,
+    )
+
+    assert verified.status is VerificationStatus.VERIFIED
+    assert failed.status is VerificationStatus.FAILED
+
+    store.save(verified)
+
+    with pytest.raises(
+        WorkflowPersistenceError,
+        match="different result",
+    ):
+        store.save(failed)
+
+
+def test_list_recent_is_latest_first(tmp_path) -> None:
+    store = SQLiteWorkflowStore(
+        tmp_path / "workflows.sqlite3"
+    )
+
+    for workflow_id in ("wf-1", "wf-2", "wf-3"):
+        store.save(make_result(workflow_id))
+
+    recent = store.list_recent(limit=2)
+
+    assert [x.workflow_id for x in recent] == [
+        "wf-3",
+        "wf-2",
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match="at least 1",
+    ):
+        store.list_recent(limit=0)
+
+
+def test_missing_result_returns_none(tmp_path) -> None:
+    store = SQLiteWorkflowStore(
+        tmp_path / "workflows.sqlite3"
+    )
+
+    assert store.get("does-not-exist") is None
+
+
+def test_non_json_serializable_result_is_rejected(
+    tmp_path,
+) -> None:
+    store = SQLiteWorkflowStore(
+        tmp_path / "workflows.sqlite3"
+    )
+    result = make_result(
+        "wf-not-json",
+        action_value=object(),
+    )
+
+    with pytest.raises(
+        WorkflowPersistenceError,
+        match="not JSON serializable",
+    ):
+        store.save(result)
+
+    assert store.get("wf-not-json") is None
+
+
+def test_corrupt_stored_payload_is_rejected(tmp_path) -> None:
+    database = tmp_path / "workflows.sqlite3"
+    store = SQLiteWorkflowStore(database)
+    store.save(make_result("wf-corrupt"))
+
+    with sqlite3.connect(database) as connection:
+        connection.execute(
+            """
+            UPDATE workflow_results
+            SET payload_json = ?
+            WHERE workflow_id = ?
+            """,
+            ("{broken-json", "wf-corrupt"),
+        )
+
+    with pytest.raises(
+        WorkflowPersistenceError,
+        match="Stored workflow result is invalid",
+    ):
+        store.get("wf-corrupt")


### PR DESCRIPTION
## Summary

Adds provider-neutral persistence for completed verified workflow results.

The new persistence layer is deliberately separate from workflow execution:
a workflow produces a `ReadActionVerifyResult`, and callers may persist that
completed result afterward.

## Public API

- `WorkflowStore`
- `SQLiteWorkflowStore`
- `WorkflowRecord`
- `WorkflowPersistenceError`

Supported operations:

- `save(result)`
- `get(workflow_id)`
- `list_recent(limit=...)`

## Storage contract

- SQLite uses Python's standard library only
- filesystem databases survive store recreation
- `:memory:` stores are supported with a shared-memory anchor connection
- saving the same result twice is idempotent
- the same `workflow_id` cannot silently overwrite a different result
- corrupt stored payloads fail explicitly
- result values must be JSON serializable

Persistence does not automatically run as part of workflow execution.

## Validation

Local checkout:

- 77 tests passed
- compileall passed
- wheel and sdist built successfully
- clean-room wheel installation passed
- SQLite file reopened using a new store instance
- complete READ/ACTION/READ result round-trip passed
- history lookup passed
- package version: `0.1.8.dev0`

Refs: WILF-023
