### PR TITLE
deps: consume Butler Core 0.1.2 [WILF-027]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "butler-core @ https://github.com/keriol/butler-core/releases/download/v0.1.1/butler_core-0.1.1-py3-none-any.whl#sha256=a5e105278ee5fa14de4cfb0d05f5061f50a3a9679a6081a42f0e1b61a82b1f99",
+    "butler-core @ https://github.com/keriol/butler-core/releases/download/v0.1.2/butler_core-0.1.2-py3-none-any.whl#sha256=bd515d0317965bb24d98a4dfc26069855b9da33184bafb4829ad91c93d14727d",
 ]
 
 [project.scripts]

--- a/tests/test_development_environment.py
+++ b/tests/test_development_environment.py
@@ -57,8 +57,8 @@ class DevelopmentEnvironmentTests(unittest.TestCase):
             dependencies[0].startswith(
                 "butler-core @ "
                 "https://github.com/keriol/butler-core/"
-                "releases/download/v0.1.1/"
-                "butler_core-0.1.1-py3-none-any.whl"
+                "releases/download/v0.1.2/"
+                "butler_core-0.1.2-py3-none-any.whl"
             )
         )
         self.assertIn(


### PR DESCRIPTION
## Summary

- pin Wilfred to the public Butler Core 0.1.2 release wheel
- verify the exact published SHA256
- update the dependency contract test to the 0.1.2 artifact
- make the shared provider-neutral planner API available to Wilfred

## Scope

This PR does not add an AI provider, OpenAI SDK, BYOK configuration, or planner integration.

## Verification

- Butler Core 0.1.2 installed from the pinned GitHub Release wheel
- `ButlerPlanner` import verified from `butler_core.planner`
- full Wilfred suite: 81 passed