### PR TITLE
chore: prepare Wilfred 0.1.8 release [WILF-028]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8.dev0"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8"}
 ```
 
 The same runtime can also be started with:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.0"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8.dev0"}
 ```
 
 The same runtime can also be started with:
@@ -68,8 +68,9 @@ Wilfred currently provides:
 - a standalone public runtime;
 - autonomous identity and configuration;
 - public tool and plugin contracts;
+- shared tool, registry and execution contracts from Butler Core 0.1.2;
 - deterministic plugin loading;
-- a native Execution Engine;
+- an Execution Engine facade backed by Butler Core;
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification without Alfred or another consumer.
 
@@ -83,18 +84,6 @@ as available:
 
 The crowdfunding campaign will only launch after the `0.2.0` release exists
 and Wilfred can demonstrate useful native behaviour.
-
-## Development
-
-Run the public test suite from the repository root:
-
-```bash
-PYTHONPATH=src python -m unittest discover -s tests -v
-```
-
-The suite includes a clean-room distribution test that builds a wheel,
-installs it into a fresh virtual environment and verifies that Wilfred runs
-without any consumer application or editable source checkout.
 
 ## Public boundary
 
@@ -130,6 +119,10 @@ python3.12 -m venv .venv
 .venv/bin/python -m pip install -e '.[dev]'
 .venv/bin/python -m pytest -q
 ~~~
+
+The suite includes a clean-room distribution test that builds a wheel,
+installs it into a fresh virtual environment and verifies that Wilfred runs
+without any consumer application or editable source checkout.
 
 See the [development guide](docs/development.md) for the complete
 compile, test, and clean-room workflow.

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,7 +32,7 @@ public distribution works without another butler repository.
 Wilfred uses the `0.1.x` series for small, verifiable milestones on the path
 to `0.2.0`.
 
-The current baseline is `0.1.6`.
+The current development baseline is `0.1.8.dev0`.
 
 Subsequent `0.1.x` versions represent concrete increments in packaging,
 distribution, onboarding and public usability. They are milestones, not a

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,7 +32,7 @@ public distribution works without another butler repository.
 Wilfred uses the `0.1.x` series for small, verifiable milestones on the path
 to `0.2.0`.
 
-The current development baseline is `0.1.8.dev0`.
+The current stable baseline is `0.1.8`.
 
 Subsequent `0.1.x` versions represent concrete increments in packaging,
 distribution, onboarding and public usability. They are milestones, not a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8.dev0"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8"}
 ```
 
 The module entrypoint is equivalent:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.0"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8.dev0"}
 ```
 
 The module entrypoint is equivalent:
@@ -146,13 +146,13 @@ The example demonstrates the public plugin lifecycle:
 From the repository root:
 
 ```bash
-PYTHONPATH=src python -m unittest discover -s tests -v
+python -m pytest -q
 ```
 
 To run only the distribution isolation test:
 
 ```bash
-PYTHONPATH=src python -m unittest     tests.test_distribution_clean_room     -v
+python -m pytest -q tests/test_distribution_clean_room.py
 ```
 
 The clean-room test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.1.8.dev0"
+version = "0.1.8"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Prepare the Wilfred 0.1.8 release.

- refresh public documentation for the current runtime
- document Butler Core 0.1.2 as the shared contract boundary
- consolidate duplicate development guidance
- align documented test commands with pytest
- bump the package from 0.1.8.dev0 to 0.1.8

## Included since 0.1.7

- provider-agnostic READ-ACTION-VERIFY workflows
- local workflow persistence
- direct consumption of Butler Core contracts
- Butler Core 0.1.2 dependency pin

## Verification

- full public suite: 81 passed
- Python compile gate passed
- wheel and sdist built successfully
- clean-room wheel install passed
- Wilfred metadata/runtime: 0.1.8
- Butler Core dependency: 0.1.2
- pip check passed
- CLI help, status and tools verified

## Release boundary

This PR does not create the v0.1.8 tag or publish a GitHub Release.
The release workflow will only be triggered after this PR is merged and the stable tag is created.