### PR TITLE
chore: open Wilfred 0.1.9 development cycle [WILF-029]

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.9.dev0"}
 ```
 
 The same runtime can also be started with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,7 +32,7 @@ public distribution works without another butler repository.
 Wilfred uses the `0.1.x` series for small, verifiable milestones on the path
 to `0.2.0`.
 
-The current stable baseline is `0.1.8`.
+The current development baseline is `0.1.9.dev0`.
 
 Subsequent `0.1.x` versions represent concrete increments in packaging,
 distribution, onboarding and public usability. They are milestones, not a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.8"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.1.9.dev0"}
 ```
 
 The module entrypoint is equivalent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.1.8"
+version = "0.1.9.dev0"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Open the Wilfred 0.1.9 development cycle after the verified 0.1.8 release.

- bump package version to 0.1.9.dev0
- align runtime examples with the development version
- update the documented development baseline

## Verification

- Wilfred metadata: 0.1.9.dev0
- Wilfred runtime: 0.1.9.dev0
- full public suite: 81 passed

## Scope

No functional feature is added in this PR.
No BYOK or provider work is included.