### PR TITLE
feat: add provider-neutral planned execution [WILF-030]

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ variables, command-line overrides, validation and precedence.
 See [Execution Engine](docs/execution-engine.md) for argument validation,
 permissions, confirmations, timeouts and structured results.
 
+See [Planned execution](docs/planned-execution.md) for the provider-neutral
+planning-to-execution bridge and its confirmation boundary.
+
 See [Verified workflows](docs/verified-workflows.md) for
 provider-agnostic READ-ACTION-VERIFY execution and verification.
 
@@ -71,6 +74,7 @@ Wilfred currently provides:
 - shared tool, registry and execution contracts from Butler Core 0.1.2;
 - deterministic plugin loading;
 - an Execution Engine facade backed by Butler Core;
+- provider-neutral planned execution backed by Butler Core;
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification without Alfred or another consumer.
 

--- a/docs/planned-execution.md
+++ b/docs/planned-execution.md
@@ -1,0 +1,49 @@
+# Planned execution
+
+Wilfred exposes a provider-neutral bridge between Butler Core planning and
+safe tool execution.
+
+The public API is:
+
+- `PlannedExecution`
+- `PlannedExecutionResult`
+
+The flow is:
+
+`request -> ButlerPlanner -> validated ToolPlan -> ExecutionEngine -> result`
+
+Planning does not execute tools and does not grant confirmation.
+
+## Confirmation boundary
+
+`PlannedExecution.execute()` uses `confirmed=False` by default.
+
+The Butler Core execution policy remains authoritative:
+
+- `READ` can execute without confirmation.
+- `ACTION` requires confirmation by default.
+- `DANGEROUS` is denied by default.
+- confirmation never overrides a policy denial.
+
+A caller may pass `confirmed=True` only after confirmation has been obtained
+outside the planner.
+
+## Provider neutrality
+
+Wilfred receives a Butler Core `PlannerProvider` from the caller.
+
+The planned-execution bridge contains no provider SDK, credentials, OpenAI
+logic, Home Assistant logic or other provider-specific behavior.
+
+A concrete provider, including future BYOK support, is a separate integration.
+
+## Scope
+
+WILF-030 does not add:
+
+- a concrete AI provider;
+- BYOK credential handling;
+- goal-oriented CLI commands;
+- Home Assistant integration;
+- automatic READ-ACTION-VERIFY construction;
+- workers, queues, schedulers or retries.

--- a/src/wilfred/__init__.py
+++ b/src/wilfred/__init__.py
@@ -35,6 +35,10 @@ from wilfred.persistence import (
     WorkflowRecord,
     WorkflowStore,
 )
+from wilfred.planning import (
+    PlannedExecution,
+    PlannedExecutionResult,
+)
 from wilfred.plugins import (
     PluginDefinition,
     PluginLoadResult,
@@ -71,6 +75,8 @@ __all__ = [
     "OutputKind",
     "OutputPriority",
     "OutputRequest",
+    "PlannedExecution",
+    "PlannedExecutionResult",
     "PluginDefinition",
     "PluginLoadResult",
     "ReadActionVerifyRequest",

--- a/src/wilfred/planning.py
+++ b/src/wilfred/planning.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from butler_core import (
+    ButlerPlanner,
+    ExecutionEngine,
+    ExecutionPolicy,
+    ExecutionRequest,
+    ExecutionResult,
+    PlannerProvider,
+    PlannerResult,
+)
+
+from wilfred.registry import ToolRegistry
+
+
+@dataclass(frozen=True)
+class PlannedExecutionResult:
+    """Result of provider-neutral planning followed by safe execution."""
+
+    planning: PlannerResult
+    execution: ExecutionResult | None = None
+
+
+class PlannedExecution:
+    """
+    Bridge a Butler Core planner result into the Execution Engine.
+
+    Planning never grants confirmation. ACTION and DANGEROUS tools
+    remain governed by ExecutionPolicy.
+    """
+
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        *,
+        provider: PlannerProvider,
+        system_prompt: str,
+        model: str | None = None,
+        enabled: bool = True,
+        policy: ExecutionPolicy | None = None,
+    ) -> None:
+        self._planner = ButlerPlanner(
+            registry,
+            provider=provider,
+            system_prompt=system_prompt,
+            model=model,
+            enabled=enabled,
+        )
+        self._engine = ExecutionEngine(
+            registry,
+            policy=policy,
+        )
+
+    def execute(
+        self,
+        message: str,
+        *,
+        confirmed: bool = False,
+    ) -> PlannedExecutionResult:
+        planning = self._planner.plan(message)
+
+        if not planning.ok:
+            return PlannedExecutionResult(
+                planning=planning,
+            )
+
+        plan = planning.plan
+
+        if plan is None or plan.tool_name is None:
+            return PlannedExecutionResult(
+                planning=planning,
+            )
+
+        execution = self._engine.execute(
+            ExecutionRequest(
+                tool_name=plan.tool_name,
+                arguments=plan.arguments,
+                confirmed=confirmed,
+            )
+        )
+
+        return PlannedExecutionResult(
+            planning=planning,
+            execution=execution,
+        )
+
+
+__all__ = [
+    "PlannedExecution",
+    "PlannedExecutionResult",
+]

--- a/tests/test_planned_execution.py
+++ b/tests/test_planned_execution.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import json
+
+from butler_core import (
+    ExecutionStatus,
+    PlannerStatus,
+)
+from wilfred.models import (
+    ToolDefinition,
+    ToolPermission,
+)
+from wilfred.registry import ToolRegistry
+
+
+def _provider_for(
+    tool_name: str | None,
+    arguments: dict | None = None,
+):
+    def provider(message, system_prompt, tools):
+        return json.dumps(
+            {
+                "tool_name": tool_name,
+                "arguments": arguments or {},
+                "confidence": 1.0,
+                "reason": "deterministic test plan",
+            }
+        )
+
+    return provider
+
+
+def _registry() -> ToolRegistry:
+    registry = ToolRegistry()
+
+    registry.register(
+        ToolDefinition(
+            name="read_state",
+            description="Read current state.",
+            handler=lambda: {"state": "on"},
+            permission=ToolPermission.READ,
+        )
+    )
+
+    registry.register(
+        ToolDefinition(
+            name="set_state",
+            description="Change state.",
+            handler=lambda state: {"state": state},
+            parameters={
+                "type": "object",
+                "properties": {
+                    "state": {
+                        "type": "string",
+                    },
+                },
+                "required": ["state"],
+                "additionalProperties": False,
+            },
+            permission=ToolPermission.ACTION,
+        )
+    )
+
+    registry.register(
+        ToolDefinition(
+            name="dangerous_reset",
+            description="Dangerous reset.",
+            handler=lambda: {"reset": True},
+            permission=ToolPermission.DANGEROUS,
+        )
+    )
+
+    return registry
+
+
+def test_read_plan_executes_without_confirmation():
+    from wilfred.planning import PlannedExecution
+
+    runtime = PlannedExecution(
+        _registry(),
+        provider=_provider_for("read_state"),
+        system_prompt="Public Wilfred test planner.",
+    )
+
+    result = runtime.execute("read the state")
+
+    assert result.planning.status is PlannerStatus.SUCCESS
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.SUCCESS
+
+
+def test_action_plan_does_not_self_confirm():
+    from wilfred.planning import PlannedExecution
+
+    runtime = PlannedExecution(
+        _registry(),
+        provider=_provider_for(
+            "set_state",
+            {"state": "off"},
+        ),
+        system_prompt="Public Wilfred test planner.",
+    )
+
+    result = runtime.execute("turn it off")
+
+    assert result.planning.status is PlannerStatus.SUCCESS
+    assert result.execution is not None
+    assert (
+        result.execution.status
+        is ExecutionStatus.CONFIRMATION_REQUIRED
+    )
+
+
+def test_explicit_confirmation_can_execute_action():
+    from wilfred.planning import PlannedExecution
+
+    runtime = PlannedExecution(
+        _registry(),
+        provider=_provider_for(
+            "set_state",
+            {"state": "off"},
+        ),
+        system_prompt="Public Wilfred test planner.",
+    )
+
+    result = runtime.execute(
+        "turn it off",
+        confirmed=True,
+    )
+
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.SUCCESS
+
+
+def test_dangerous_plan_remains_denied_by_default():
+    from wilfred.planning import PlannedExecution
+
+    runtime = PlannedExecution(
+        _registry(),
+        provider=_provider_for("dangerous_reset"),
+        system_prompt="Public Wilfred test planner.",
+    )
+
+    result = runtime.execute(
+        "reset everything",
+        confirmed=True,
+    )
+
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.DENIED
+
+
+def test_no_tool_plan_does_not_execute():
+    from wilfred.planning import PlannedExecution
+
+    runtime = PlannedExecution(
+        _registry(),
+        provider=_provider_for(None),
+        system_prompt="Public Wilfred test planner.",
+    )
+
+    result = runtime.execute("just chatting")
+
+    assert result.planning.status is PlannerStatus.SUCCESS
+    assert result.planning.plan is not None
+    assert result.planning.plan.tool_name is None
+    assert result.execution is None
+
+
+def test_planner_failure_does_not_execute():
+    from wilfred.planning import PlannedExecution
+
+    runtime = PlannedExecution(
+        _registry(),
+        provider=lambda message, prompt, tools: "not-json",
+        system_prompt="Public Wilfred test planner.",
+    )
+
+    result = runtime.execute("anything")
+
+    assert result.planning.status is PlannerStatus.INVALID_RESPONSE
+    assert result.execution is None
+
+
+def test_planned_execution_is_public_api():
+    from wilfred import (
+        PlannedExecution as PublicPlannedExecution,
+        PlannedExecutionResult as PublicPlannedExecutionResult,
+    )
+    from wilfred.planning import (
+        PlannedExecution,
+        PlannedExecutionResult,
+    )
+
+    assert PublicPlannedExecution is PlannedExecution
+    assert PublicPlannedExecutionResult is PlannedExecutionResult


### PR DESCRIPTION
## Summary

Add the provider-neutral bridge between Butler Core planning and Wilfred tool execution.

- expose `PlannedExecution` and `PlannedExecutionResult`
- convert validated `ToolPlan` results into `ExecutionRequest`
- keep Butler Core `ExecutionPolicy` authoritative
- preserve explicit confirmation boundaries
- document the public planning-to-execution contract

## Safety boundary

The planner never grants confirmation.

- READ may execute without confirmation
- ACTION requires confirmation by default
- DANGEROUS remains denied by default
- `confirmed=True` must come from the caller, outside planning

## Provider boundary

No concrete AI provider is included.

This PR adds:

`request -> ButlerPlanner -> validated ToolPlan -> ExecutionEngine -> result`

It does not add:

- OpenAI or another provider SDK
- BYOK credential handling
- Home Assistant integration
- goal-oriented CLI commands
- automatic READ-ACTION-VERIFY construction
- workers, queues, schedulers or retries

## Verification

- planned execution tests: 7 passed
- full suite: 88 passed