### PR TITLE
feat: add provider-neutral goal runtime [WILF-031]

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ permissions, confirmations, timeouts and structured results.
 See [Planned execution](docs/planned-execution.md) for the provider-neutral
 planning-to-execution bridge and its confirmation boundary.
 
+See [Wilfred runtime](docs/runtime.md) for the public goal-oriented
+composition API.
+
 See [Verified workflows](docs/verified-workflows.md) for
 provider-agnostic READ-ACTION-VERIFY execution and verification.
 
@@ -75,6 +78,7 @@ Wilfred currently provides:
 - deterministic plugin loading;
 - an Execution Engine facade backed by Butler Core;
 - provider-neutral planned execution backed by Butler Core;
+- a public goal-oriented `WilfredRuntime` composition API;
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification without Alfred or another consumer.
 
@@ -82,7 +86,7 @@ The following capabilities are still under development and are not presented
 as available:
 
 - native Butler capabilities;
-- goal-oriented CLI and API;
+- goal-oriented CLI;
 - the public Home Assistant adapter;
 - the Wilfred `0.2.0` public alpha.
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,50 @@
+# Wilfred runtime
+
+`WilfredRuntime` is the public composition layer for goal-oriented Wilfred
+execution.
+
+It combines existing public components rather than replacing them:
+
+- a `ToolRegistry`;
+- Wilfred native READ tools;
+- optional public plugins;
+- provider-neutral `PlannedExecution`;
+- Butler Core `ExecutionPolicy`.
+
+A caller supplies a Butler Core `PlannerProvider` and a system prompt.
+
+The runtime can then accept a goal through `execute_goal()`.
+
+## Execution boundary
+
+`execute_goal(message)` plans and executes through the existing Wilfred and
+Butler Core contracts.
+
+Confirmation is explicit:
+
+- `confirmed=False` is the default;
+- the planner never grants confirmation;
+- `ACTION` remains subject to confirmation policy;
+- `DANGEROUS` remains subject to dangerous-tool policy.
+
+`confirmed=True` must come from the caller after confirmation has been
+obtained outside the planner.
+
+## Plugins
+
+Optional `PluginDefinition` objects are loaded into the same registry as the
+native Wilfred tools.
+
+`tool_names()` exposes the resulting deterministic registry contents.
+
+## Scope
+
+`WilfredRuntime` does not provide:
+
+- a concrete AI provider;
+- provider credentials or BYOK;
+- a goal CLI command;
+- Home Assistant integration;
+- background workers, queues, schedulers or retries.
+
+Those remain separate integration concerns.

--- a/src/wilfred/__init__.py
+++ b/src/wilfred/__init__.py
@@ -60,6 +60,8 @@ try:
 except PackageNotFoundError:
     __version__ = "0+unknown"
 
+from wilfred.runtime import WilfredRuntime
+
 __all__ = [
     "ButlerIdentity",
     "ConfigurationError",
@@ -77,6 +79,7 @@ __all__ = [
     "OutputRequest",
     "PlannedExecution",
     "PlannedExecutionResult",
+    "WilfredRuntime",
     "PluginDefinition",
     "PluginLoadResult",
     "ReadActionVerifyRequest",

--- a/src/wilfred/runtime.py
+++ b/src/wilfred/runtime.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from butler_core import (
+    ExecutionPolicy,
+    PlannerProvider,
+)
+
+from wilfred.native import register_native_tools
+from wilfred.planning import (
+    PlannedExecution,
+    PlannedExecutionResult,
+)
+from wilfred.plugins import (
+    PluginDefinition,
+    load_plugins,
+)
+from wilfred.registry import ToolRegistry
+
+
+class WilfredRuntime:
+    """Compose Wilfred's public tools, plugins and planned execution."""
+
+    def __init__(
+        self,
+        *,
+        provider: PlannerProvider,
+        system_prompt: str,
+        plugins: Iterable[PluginDefinition] = (),
+        model: str | None = None,
+        enabled: bool = True,
+        policy: ExecutionPolicy | None = None,
+    ) -> None:
+        registry = ToolRegistry()
+
+        register_native_tools(registry)
+        load_plugins(registry, plugins)
+
+        self._registry = registry
+        self._planned_execution = PlannedExecution(
+            registry,
+            provider=provider,
+            system_prompt=system_prompt,
+            model=model,
+            enabled=enabled,
+            policy=policy,
+        )
+
+    def tool_names(self) -> list[str]:
+        return self._registry.names()
+
+    def execute_goal(
+        self,
+        message: str,
+        *,
+        confirmed: bool = False,
+    ) -> PlannedExecutionResult:
+        return self._planned_execution.execute(
+            message,
+            confirmed=confirmed,
+        )
+
+
+__all__ = ["WilfredRuntime"]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import json
+
+from butler_core import ExecutionStatus, PlannerStatus
+
+from wilfred.models import ToolDefinition, ToolPermission
+from wilfred.plugins import PluginDefinition
+
+
+def _provider(tool_name, arguments=None):
+    def provider(message, system_prompt, tools):
+        return json.dumps(
+            {
+                "tool_name": tool_name,
+                "arguments": arguments or {},
+                "confidence": 1.0,
+                "reason": "deterministic runtime test",
+            }
+        )
+
+    return provider
+
+
+def test_runtime_registers_native_tools():
+    from wilfred.runtime import WilfredRuntime
+
+    runtime = WilfredRuntime(
+        provider=_provider(None),
+        system_prompt="Test Wilfred runtime.",
+    )
+
+    assert runtime.tool_names() == [
+        "wilfred_status",
+        "wilfred_tools",
+    ]
+
+
+def test_runtime_loads_public_plugins():
+    from wilfred.runtime import WilfredRuntime
+
+    plugin = PluginDefinition(
+        name="test.read",
+        register=lambda registry: registry.register(
+            ToolDefinition(
+                name="test_read",
+                description="Return a test value.",
+                handler=lambda: {"value": 42},
+                permission=ToolPermission.READ,
+            )
+        ),
+    )
+
+    runtime = WilfredRuntime(
+        provider=_provider("test_read"),
+        system_prompt="Test Wilfred runtime.",
+        plugins=[plugin],
+    )
+
+    assert runtime.tool_names() == [
+        "test_read",
+        "wilfred_status",
+        "wilfred_tools",
+    ]
+
+    result = runtime.execute_goal("read test value")
+
+    assert result.planning.status is PlannerStatus.SUCCESS
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.SUCCESS
+    assert result.execution.value == {"value": 42}
+
+
+def test_runtime_executes_native_goal():
+    from wilfred.runtime import WilfredRuntime
+
+    runtime = WilfredRuntime(
+        provider=_provider("wilfred_status"),
+        system_prompt="Test Wilfred runtime.",
+    )
+
+    result = runtime.execute_goal("what is your status?")
+
+    assert result.planning.status is PlannerStatus.SUCCESS
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.SUCCESS
+    assert result.execution.value["name"] == "Wilfred"
+
+
+def test_runtime_does_not_self_confirm_actions():
+    from wilfred.runtime import WilfredRuntime
+
+    plugin = PluginDefinition(
+        name="test.action",
+        register=lambda registry: registry.register(
+            ToolDefinition(
+                name="test_action",
+                description="Perform a test action.",
+                handler=lambda: {"done": True},
+                permission=ToolPermission.ACTION,
+            )
+        ),
+    )
+
+    runtime = WilfredRuntime(
+        provider=_provider("test_action"),
+        system_prompt="Test Wilfred runtime.",
+        plugins=[plugin],
+    )
+
+    result = runtime.execute_goal("do the action")
+
+    assert result.execution is not None
+    assert (
+        result.execution.status
+        is ExecutionStatus.CONFIRMATION_REQUIRED
+    )
+
+
+def test_runtime_accepts_explicit_confirmation():
+    from wilfred.runtime import WilfredRuntime
+
+    plugin = PluginDefinition(
+        name="test.action",
+        register=lambda registry: registry.register(
+            ToolDefinition(
+                name="test_action",
+                description="Perform a test action.",
+                handler=lambda: {"done": True},
+                permission=ToolPermission.ACTION,
+            )
+        ),
+    )
+
+    runtime = WilfredRuntime(
+        provider=_provider("test_action"),
+        system_prompt="Test Wilfred runtime.",
+        plugins=[plugin],
+    )
+
+    result = runtime.execute_goal(
+        "do the action",
+        confirmed=True,
+    )
+
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.SUCCESS
+    assert result.execution.value == {"done": True}
+
+
+def test_runtime_is_public_api():
+    from wilfred import WilfredRuntime as PublicWilfredRuntime
+    from wilfred.runtime import WilfredRuntime
+
+    assert PublicWilfredRuntime is WilfredRuntime


### PR DESCRIPTION
## Summary

Add `WilfredRuntime`, the public provider-neutral composition layer for
goal-oriented Wilfred execution.

The runtime composes:

- Wilfred native READ tools
- optional public plugins
- provider-neutral `PlannedExecution`
- the existing Butler Core `ExecutionPolicy`

It exposes `execute_goal(message, confirmed=False)` and deterministic
`tool_names()` introspection.

## Safety boundary

The runtime does not weaken execution policy.

- planning never grants confirmation
- ACTION remains subject to confirmation policy
- DANGEROUS remains subject to dangerous-tool policy
- explicit confirmation must come from the caller

## Scope

This PR does not add:

- a concrete AI provider
- BYOK credentials
- OpenAI integration
- goal-oriented CLI commands
- Home Assistant integration
- workers, queues, schedulers or retries

## Documentation

The public `WilfredRuntime` API is documented and the README now distinguishes
the available goal-oriented API from the still-unimplemented goal-oriented CLI.

## Verification

- runtime tests: 6 passed
- full suite: 94 passed