### PR TITLE
feat: add optional OpenAI BYOK planner provider [WILF-032]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ planning-to-execution bridge and its confirmation boundary.
 See [Wilfred runtime](docs/runtime.md) for the public goal-oriented
 composition API.
 
+See [OpenAI planner provider](docs/openai-provider.md) for optional BYOK
+planning with an environment-only API key.
+
 See [Verified workflows](docs/verified-workflows.md) for
 provider-agnostic READ-ACTION-VERIFY execution and verification.
 
@@ -79,6 +82,7 @@ Wilfred currently provides:
 - an Execution Engine facade backed by Butler Core;
 - provider-neutral planned execution backed by Butler Core;
 - a public goal-oriented `WilfredRuntime` composition API;
+- an optional OpenAI BYOK planner provider;
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification without Alfred or another consumer.
 

--- a/docs/openai-provider.md
+++ b/docs/openai-provider.md
@@ -1,0 +1,47 @@
+# OpenAI planner provider
+
+Wilfred includes an optional OpenAI implementation of the Butler Core
+`PlannerProvider` contract.
+
+The provider is exposed from `wilfred.providers` as
+`OpenAIPlannerProvider`.
+
+## Installation
+
+OpenAI support is optional:
+
+`python -m pip install 'wilfred-butler[openai]'`
+
+The base Wilfred installation does not require the OpenAI SDK.
+
+## BYOK credential
+
+The OpenAI API key is supplied only through:
+
+`WILFRED_OPENAI_API_KEY`
+
+The key is intentionally excluded from:
+
+- TOML configuration;
+- command-line options;
+- `RuntimeConfig`;
+- runtime status;
+- provider output.
+
+A caller creates the provider with `OpenAIPlannerProvider.from_environment()`.
+
+## Planning
+
+The adapter uses the OpenAI Responses API and requests a structured JSON tool
+plan matching the Butler Core planner contract.
+
+Wilfred still validates that plan before execution.
+
+The OpenAI provider does not execute tools and does not grant confirmation.
+
+## Scope
+
+This provider does not change Butler Core and does not make OpenAI a mandatory
+Wilfred dependency.
+
+It does not add Home Assistant integration or a goal-oriented CLI command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ wilfred = "wilfred.__main__:main"
 where = ["src"]
 
 [project.optional-dependencies]
+openai = [
+    "openai>=2.53,<3",
+]
 dev = [
     "pytest>=9,<10",
     "setuptools>=68",

--- a/src/wilfred/providers/__init__.py
+++ b/src/wilfred/providers/__init__.py
@@ -1,0 +1,11 @@
+"""Optional concrete planner providers for Wilfred."""
+
+from wilfred.providers.openai import (
+    OpenAIPlannerProvider,
+    OpenAIProviderConfigurationError,
+)
+
+__all__ = [
+    "OpenAIPlannerProvider",
+    "OpenAIProviderConfigurationError",
+]

--- a/src/wilfred/providers/openai.py
+++ b/src/wilfred/providers/openai.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+import json
+import os
+from typing import Any
+
+
+ClientFactory = Callable[..., Any]
+
+
+class OpenAIProviderConfigurationError(ValueError):
+    """Raised when the OpenAI provider cannot be configured safely."""
+
+
+def _default_client_factory(**kwargs: Any) -> Any:
+    try:
+        from openai import OpenAI
+    except ImportError as exc:
+        raise OpenAIProviderConfigurationError(
+            "OpenAI provider requires the optional 'openai' package."
+        ) from exc
+
+    return OpenAI(**kwargs)
+
+
+class OpenAIPlannerProvider:
+    """OpenAI Responses API adapter for Butler Core planning."""
+
+    def __init__(
+        self,
+        *,
+        client: Any,
+        model: str,
+    ) -> None:
+        resolved_model = model.strip()
+
+        if not resolved_model:
+            raise OpenAIProviderConfigurationError(
+                "OpenAI model cannot be empty."
+            )
+
+        self._client = client
+        self._model = resolved_model
+
+    @classmethod
+    def from_environment(
+        cls,
+        *,
+        model: str,
+        environ: Mapping[str, str] | None = None,
+        client_factory: ClientFactory | None = None,
+    ) -> OpenAIPlannerProvider:
+        effective_environment = (
+            os.environ
+            if environ is None
+            else environ
+        )
+
+        api_key = effective_environment.get(
+            "WILFRED_OPENAI_API_KEY",
+            "",
+        ).strip()
+
+        if not api_key:
+            raise OpenAIProviderConfigurationError(
+                "WILFRED_OPENAI_API_KEY is required "
+                "for the OpenAI provider."
+            )
+
+        factory = client_factory or _default_client_factory
+        client = factory(api_key=api_key)
+
+        return cls(
+            client=client,
+            model=model,
+        )
+
+    def __call__(
+        self,
+        message: str,
+        system_prompt: str,
+        tools: list[dict[str, Any]],
+    ) -> str:
+        tool_catalog = json.dumps(
+            tools,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+
+        instructions = (
+            f"{system_prompt.strip()}\n\n"
+            "Available Wilfred tools:\n"
+            f"{tool_catalog}\n\n"
+            "Return exactly one tool plan matching "
+            "the required JSON schema."
+        )
+
+        response = self._client.responses.create(
+            model=self._model,
+            instructions=instructions,
+            input=message,
+            store=False,
+            text={
+                "format": {
+                    "type": "json_schema",
+                    "name": "wilfred_tool_plan",
+                    "strict": True,
+                    "schema": {
+                        "type": "object",
+                        "properties": {
+                            "tool_name": {
+                                "type": [
+                                    "string",
+                                    "null",
+                                ],
+                            },
+                            "arguments": {
+                                "type": "object",
+                                "additionalProperties": True,
+                            },
+                            "confidence": {
+                                "type": "number",
+                                "minimum": 0,
+                                "maximum": 1,
+                            },
+                            "reason": {
+                                "type": "string",
+                            },
+                        },
+                        "required": [
+                            "tool_name",
+                            "arguments",
+                            "confidence",
+                            "reason",
+                        ],
+                        "additionalProperties": False,
+                    },
+                }
+            },
+        )
+
+        output_text = response.output_text
+
+        if not isinstance(output_text, str):
+            raise TypeError(
+                "OpenAI response output_text must be a string."
+            )
+
+        return output_text
+
+
+__all__ = [
+    "OpenAIPlannerProvider",
+    "OpenAIProviderConfigurationError",
+]

--- a/tests/test_openai_provider.py
+++ b/tests/test_openai_provider.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+SECRET = "sk-test-secret-never-leak"
+
+
+class FakeResponses:
+    def __init__(self, output_text: str) -> None:
+        self.output_text = output_text
+        self.calls: list[dict] = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return SimpleNamespace(
+            output_text=self.output_text,
+        )
+
+
+class FakeClient:
+    def __init__(self, output_text: str) -> None:
+        self.responses = FakeResponses(output_text)
+
+
+def _plan_json() -> str:
+    return json.dumps(
+        {
+            "tool_name": "wilfred_status",
+            "arguments": {},
+            "confidence": 1.0,
+            "reason": "Read runtime status.",
+        }
+    )
+
+
+def test_from_environment_uses_namespaced_secret():
+    from wilfred.providers.openai import OpenAIPlannerProvider
+
+    captured = {}
+    client = FakeClient(_plan_json())
+
+    def factory(**kwargs):
+        captured.update(kwargs)
+        return client
+
+    provider = OpenAIPlannerProvider.from_environment(
+        model="test-model",
+        environ={
+            "WILFRED_OPENAI_API_KEY": SECRET,
+        },
+        client_factory=factory,
+    )
+
+    assert captured == {
+        "api_key": SECRET,
+    }
+
+    assert SECRET not in repr(provider)
+    assert SECRET not in repr(vars(provider))
+
+
+def test_missing_key_is_rejected_without_secret_output():
+    from wilfred.providers.openai import (
+        OpenAIPlannerProvider,
+        OpenAIProviderConfigurationError,
+    )
+
+    with pytest.raises(
+        OpenAIProviderConfigurationError,
+        match="WILFRED_OPENAI_API_KEY",
+    ) as error:
+        OpenAIPlannerProvider.from_environment(
+            model="test-model",
+            environ={},
+            client_factory=lambda **kwargs: None,
+        )
+
+    assert "sk-" not in str(error.value)
+
+
+def test_provider_returns_response_output_text():
+    from wilfred.providers.openai import OpenAIPlannerProvider
+
+    expected = _plan_json()
+    client = FakeClient(expected)
+
+    provider = OpenAIPlannerProvider(
+        client=client,
+        model="test-model",
+    )
+
+    result = provider(
+        "what is your status?",
+        "Plan Wilfred tool use.",
+        [
+            {
+                "name": "wilfred_status",
+                "description": "Return runtime status.",
+                "category": "native",
+                "permission": "READ",
+                "parameters": {
+                    "type": "object",
+                    "properties": {},
+                },
+            }
+        ],
+    )
+
+    assert result == expected
+
+
+def test_provider_uses_responses_structured_output():
+    from wilfred.providers.openai import OpenAIPlannerProvider
+
+    client = FakeClient(_plan_json())
+
+    provider = OpenAIPlannerProvider(
+        client=client,
+        model="test-model",
+    )
+
+    provider(
+        "what is your status?",
+        "Plan Wilfred tool use.",
+        [],
+    )
+
+    assert len(client.responses.calls) == 1
+
+    call = client.responses.calls[0]
+
+    assert call["model"] == "test-model"
+    assert call["input"] == "what is your status?"
+    assert call["store"] is False
+
+    output_format = call["text"]["format"]
+
+    assert output_format["type"] == "json_schema"
+    assert output_format["name"] == "wilfred_tool_plan"
+    assert output_format["strict"] is True
+
+    schema = output_format["schema"]
+
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == {
+        "tool_name",
+        "arguments",
+        "confidence",
+        "reason",
+    }
+
+
+def test_provider_supplies_prompt_and_tool_catalog():
+    from wilfred.providers.openai import OpenAIPlannerProvider
+
+    client = FakeClient(_plan_json())
+
+    provider = OpenAIPlannerProvider(
+        client=client,
+        model="test-model",
+    )
+
+    provider(
+        "check status",
+        "PUBLIC SYSTEM PROMPT",
+        [
+            {
+                "name": "wilfred_status",
+                "description": "Return status.",
+                "category": "native",
+                "permission": "READ",
+                "parameters": {},
+            }
+        ],
+    )
+
+    instructions = client.responses.calls[0]["instructions"]
+
+    assert "PUBLIC SYSTEM PROMPT" in instructions
+    assert "wilfred_status" in instructions
+    assert SECRET not in instructions
+
+
+def test_openai_provider_is_public_provider_api():
+    from wilfred.providers import (
+        OpenAIPlannerProvider as PublicProvider,
+        OpenAIProviderConfigurationError as PublicError,
+    )
+    from wilfred.providers.openai import (
+        OpenAIPlannerProvider,
+        OpenAIProviderConfigurationError,
+    )
+
+    assert PublicProvider is OpenAIPlannerProvider
+    assert PublicError is OpenAIProviderConfigurationError


### PR DESCRIPTION
## Summary

Add the first concrete Wilfred planner provider while keeping Butler Core
provider-neutral.

This PR adds:

- `OpenAIPlannerProvider`
- optional `wilfred-butler[openai]` dependency
- OpenAI Responses API structured tool planning
- BYOK credential loading through `WILFRED_OPENAI_API_KEY`
- provider documentation and README integration

## Credential boundary

The OpenAI API key is environment-only.

It is not accepted through:

- TOML configuration
- command-line arguments
- `RuntimeConfig`
- runtime status
- provider output

The provider does not retain the API key in its own state.

## Architecture

The OpenAI adapter implements the existing Butler Core `PlannerProvider`
contract.

It does not:

- execute tools
- grant confirmation
- modify Butler Core
- make OpenAI a mandatory Wilfred dependency
- add Home Assistant integration
- add the goal-oriented CLI

Execution and confirmation remain governed by the existing Wilfred and
Butler Core execution path.

## Verification

- OpenAI provider tests: 6 passed
- full suite: 100 passed
- base Wilfred imports without the OpenAI SDK
- clean-room `wilfred-butler[openai]` installation succeeded
- OpenAI SDK 2.53.0 verified
- `pip check` clean
- default client construction verified without an API request