### PR TITLE
feat: add provider latency acknowledgement [WILF-033]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ planning-to-execution bridge and its confirmation boundary.
 See [Wilfred runtime](docs/runtime.md) for the public goal-oriented
 composition API.
 
+See [Provider latency acknowledgement](docs/provider-latency-acknowledgement.md)
+for optional pre-planning conversational feedback.
+
 See [OpenAI planner provider](docs/openai-provider.md) for optional BYOK
 planning with an environment-only API key.
 

--- a/docs/provider-latency-acknowledgement.md
+++ b/docs/provider-latency-acknowledgement.md
@@ -1,0 +1,15 @@
+# Provider latency acknowledgement
+
+Voice and conversational consumers can emit a short acknowledgement before Wilfred starts goal planning, avoiding perceived silence.
+
+The acknowledgement is optional and belongs to the interaction layer, not to a planner provider.
+
+A consumer supplies an `OutputAdapter` through `acknowledgement_adapter` and localized `acknowledgement_text`, for example `"Ci sto pensando."`.
+
+`WilfredRuntime.execute_goal()` attempts delivery immediately before calling the planner.
+
+Delivery is best-effort. Failure does not block planning.
+
+An acknowledgement never confirms an ACTION or DANGEROUS tool and never changes execution policy.
+
+Wilfred provides no default phrase. Consumers choose wording and concrete output integration.

--- a/src/wilfred/runtime.py
+++ b/src/wilfred/runtime.py
@@ -8,6 +8,11 @@ from butler_core import (
 )
 
 from wilfred.native import register_native_tools
+from wilfred.output import (
+    OutputAdapter,
+    OutputKind,
+    OutputRequest,
+)
 from wilfred.planning import (
     PlannedExecution,
     PlannedExecutionResult,
@@ -31,6 +36,8 @@ class WilfredRuntime:
         model: str | None = None,
         enabled: bool = True,
         policy: ExecutionPolicy | None = None,
+        acknowledgement_adapter: OutputAdapter | None = None,
+        acknowledgement_text: str | None = None,
     ) -> None:
         registry = ToolRegistry()
 
@@ -38,6 +45,8 @@ class WilfredRuntime:
         load_plugins(registry, plugins)
 
         self._registry = registry
+        self._acknowledgement_adapter = acknowledgement_adapter
+        self._acknowledgement_text = acknowledgement_text
         self._planned_execution = PlannedExecution(
             registry,
             provider=provider,
@@ -56,10 +65,31 @@ class WilfredRuntime:
         *,
         confirmed: bool = False,
     ) -> PlannedExecutionResult:
+        self._acknowledge_provider_latency()
+
         return self._planned_execution.execute(
             message,
             confirmed=confirmed,
         )
+
+    def _acknowledge_provider_latency(self) -> None:
+        adapter = self._acknowledgement_adapter
+        text = self._acknowledgement_text
+
+        if adapter is None or text is None:
+            return
+
+        try:
+            adapter.deliver(
+                OutputRequest(
+                    content=text,
+                    kind=OutputKind.SPEECH,
+                )
+            )
+        except Exception:
+            # A best-effort acknowledgement must never block
+            # planning or alter execution authorization.
+            return
 
 
 __all__ = ["WilfredRuntime"]

--- a/tests/test_runtime_acknowledgement.py
+++ b/tests/test_runtime_acknowledgement.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+
+from butler_core import ExecutionStatus
+
+from wilfred import (
+    OutputCapability,
+    OutputDeliveryResult,
+    OutputDeliveryStatus,
+    OutputKind,
+    OutputRequest,
+    WilfredRuntime,
+)
+from wilfred.models import ToolDefinition, ToolPermission
+from wilfred.plugins import PluginDefinition
+
+
+class RecordingSpeechAdapter:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        status: OutputDeliveryStatus = OutputDeliveryStatus.DELIVERED,
+    ) -> None:
+        self.events = events
+        self.status = status
+        self.requests: list[OutputRequest] = []
+
+    @property
+    def name(self) -> str:
+        return "recording-speech"
+
+    def capabilities(self) -> frozenset[OutputCapability]:
+        return frozenset({OutputCapability.SPEECH})
+
+    def deliver(
+        self,
+        request: OutputRequest,
+    ) -> OutputDeliveryResult:
+        self.events.append("ack")
+        self.requests.append(request)
+
+        return OutputDeliveryResult(
+            request_id=request.request_id,
+            adapter_name=self.name,
+            status=self.status,
+        )
+
+
+def _provider(events: list[str], tool_name=None):
+    def provider(message, system_prompt, tools):
+        events.append("provider")
+
+        return json.dumps(
+            {
+                "tool_name": tool_name,
+                "arguments": {},
+                "confidence": 1.0,
+                "reason": "deterministic test",
+            }
+        )
+
+    return provider
+
+
+def test_acknowledgement_happens_before_provider_call():
+    events: list[str] = []
+    adapter = RecordingSpeechAdapter(events)
+
+    runtime = WilfredRuntime(
+        provider=_provider(events),
+        system_prompt="Test runtime.",
+        acknowledgement_adapter=adapter,
+        acknowledgement_text="Thinking about it.",
+    )
+
+    runtime.execute_goal("hello")
+
+    assert events == ["ack", "provider"]
+
+    request = adapter.requests[0]
+
+    assert request.kind is OutputKind.SPEECH
+    assert request.content == "Thinking about it."
+
+
+def test_runtime_without_acknowledgement_is_unchanged():
+    events: list[str] = []
+
+    runtime = WilfredRuntime(
+        provider=_provider(events),
+        system_prompt="Test runtime.",
+    )
+
+    runtime.execute_goal("hello")
+
+    assert events == ["provider"]
+
+
+def test_failed_acknowledgement_does_not_block_planning():
+    events: list[str] = []
+
+    runtime = WilfredRuntime(
+        provider=_provider(events),
+        system_prompt="Test runtime.",
+        acknowledgement_adapter=RecordingSpeechAdapter(
+            events,
+            status=OutputDeliveryStatus.FAILED,
+        ),
+        acknowledgement_text="Thinking about it.",
+    )
+
+    result = runtime.execute_goal("hello")
+
+    assert events == ["ack", "provider"]
+    assert result.planning.ok
+
+
+def test_acknowledgement_never_grants_action_confirmation():
+    events: list[str] = []
+
+    plugin = PluginDefinition(
+        name="test.action",
+        register=lambda registry: registry.register(
+            ToolDefinition(
+                name="test_action",
+                description="Perform test action.",
+                handler=lambda: {"done": True},
+                permission=ToolPermission.ACTION,
+            )
+        ),
+    )
+
+    runtime = WilfredRuntime(
+        provider=_provider(events, "test_action"),
+        system_prompt="Test runtime.",
+        plugins=[plugin],
+        acknowledgement_adapter=RecordingSpeechAdapter(events),
+        acknowledgement_text="Thinking about it.",
+    )
+
+    result = runtime.execute_goal("do it")
+
+    assert events == ["ack", "provider"]
+    assert result.execution is not None
+    assert (
+        result.execution.status
+        is ExecutionStatus.CONFIRMATION_REQUIRED
+    )


### PR DESCRIPTION
## Summary

Add optional conversational acknowledgement before goal planning, avoiding perceived silence while an AI provider is responding.

## Behavior

- acknowledgement occurs immediately before planner/provider invocation
- wording is supplied by the consumer and can be localized
- delivery uses the public OutputAdapter contract
- delivery is best-effort and never blocks planning
- acknowledgement never grants ACTION or DANGEROUS confirmation
- no provider-specific behavior is added

## Verification

- acknowledgement tests: 4 passed
- runtime tests: 6 passed
- full suite: 104 passed
- provider implementation unchanged