### PR TITLE
feat: add goal-oriented CLI [WILF-034]

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ planning-to-execution bridge and its confirmation boundary.
 See [Wilfred runtime](docs/runtime.md) for the public goal-oriented
 composition API.
 
+See [Goal-oriented CLI](docs/goal-cli.md) for natural-language goal
+planning and execution from the command line.
+
 See [Provider latency acknowledgement](docs/provider-latency-acknowledgement.md)
 for optional pre-planning conversational feedback.
 
@@ -85,6 +88,7 @@ Wilfred currently provides:
 - an Execution Engine facade backed by Butler Core;
 - provider-neutral planned execution backed by Butler Core;
 - a public goal-oriented `WilfredRuntime` composition API;
+- a goal-oriented CLI for provider-backed planning and execution;
 - an optional OpenAI BYOK planner provider;
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification without Alfred or another consumer.
@@ -93,7 +97,6 @@ The following capabilities are still under development and are not presented
 as available:
 
 - native Butler capabilities;
-- goal-oriented CLI;
 - the public Home Assistant adapter;
 - the Wilfred `0.2.0` public alpha.
 

--- a/docs/goal-cli.md
+++ b/docs/goal-cli.md
@@ -1,0 +1,19 @@
+# Goal-oriented CLI
+
+Wilfred can plan and execute a natural-language goal through a configured planner provider.
+
+Example:
+
+`wilfred goal "what is your status?" --provider openai --model MODEL`
+
+OpenAI credentials are never accepted as CLI arguments. The provider reads `WILFRED_OPENAI_API_KEY` from the environment.
+
+`--confirmed` is the only goal CLI flag that explicitly grants ACTION confirmation. Without it, confirmation defaults to false.
+
+DANGEROUS tools remain governed by the execution policy and are denied by the default policy.
+
+The planner selects a registered tool and constructs its arguments. It does not execute tools or bypass execution policy.
+
+The current planner contract produces one validated `ToolPlan` per goal. Multi-tool planning chains are not part of this CLI contract yet.
+
+The command emits planning and execution results as JSON.

--- a/src/wilfred/__main__.py
+++ b/src/wilfred/__main__.py
@@ -14,7 +14,12 @@ from wilfred.config import (
     load_config,
 )
 from wilfred.native import register_native_tools
+from wilfred.providers import (
+    OpenAIPlannerProvider,
+    OpenAIProviderConfigurationError,
+)
 from wilfred.registry import ToolRegistry
+from wilfred.runtime import WilfredRuntime
 
 
 def runtime_status(
@@ -75,6 +80,31 @@ def build_parser() -> argparse.ArgumentParser:
         help="List Wilfred native capabilities.",
     )
 
+    goal = commands.add_parser(
+        "goal",
+        help="Plan and execute a goal through a planner provider.",
+    )
+    goal.add_argument(
+        "message",
+        help="Natural-language goal to plan.",
+    )
+    goal.add_argument(
+        "--provider",
+        choices=("openai",),
+        required=True,
+        help="Planner provider.",
+    )
+    goal.add_argument(
+        "--model",
+        required=True,
+        help="Provider model identifier.",
+    )
+    goal.add_argument(
+        "--confirmed",
+        action="store_true",
+        help="Explicitly confirm ACTION execution.",
+    )
+
     return parser
 
 
@@ -110,6 +140,81 @@ def run_native_command(command: str) -> int:
     return 0
 
 
+def run_goal_command(
+    *,
+    message: str,
+    provider_name: str,
+    model: str,
+    confirmed: bool,
+    environ: Mapping[str, str],
+) -> int:
+    if provider_name != "openai":
+        raise ValueError(
+            f"Unsupported planner provider: {provider_name}"
+        )
+
+    provider = OpenAIPlannerProvider.from_environment(
+        model=model,
+        environ=environ,
+    )
+
+    runtime = WilfredRuntime(
+        provider=provider,
+        system_prompt=(
+            "Select the appropriate Wilfred tool for the "
+            "user's goal using only the available tools."
+        ),
+    )
+
+    result = runtime.execute_goal(
+        message,
+        confirmed=confirmed,
+    )
+
+    plan = result.planning.plan
+
+    planning = {
+        "status": result.planning.status.value,
+        "duration_ms": result.planning.duration_ms,
+        "plan": (
+            None
+            if plan is None
+            else {
+                "tool_name": plan.tool_name,
+                "arguments": dict(plan.arguments),
+                "confidence": plan.confidence,
+                "reason": plan.reason,
+            }
+        ),
+        "model": result.planning.model,
+        "error_code": result.planning.error_code,
+        "error_message": result.planning.error_message,
+        "validation_errors": [
+            str(item)
+            for item in result.planning.validation_errors
+        ],
+    }
+
+    payload = {
+        "planning": planning,
+        "execution": (
+            None
+            if result.execution is None
+            else result.execution.to_dict()
+        ),
+    }
+
+    print(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+
+    return 0
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -118,8 +223,30 @@ def main(
     parser = build_parser()
     arguments = parser.parse_args(argv)
 
-    if arguments.command is not None:
+    if arguments.command in {"status", "tools"}:
         return run_native_command(arguments.command)
+
+    if arguments.command == "goal":
+        effective_environment = (
+            os.environ
+            if environ is None
+            else environ
+        )
+
+        try:
+            return run_goal_command(
+                message=arguments.message,
+                provider_name=arguments.provider,
+                model=arguments.model,
+                confirmed=arguments.confirmed,
+                environ=effective_environment,
+            )
+        except OpenAIProviderConfigurationError as exc:
+            print(
+                f"wilfred: configuration error: {exc}",
+                file=sys.stderr,
+            )
+            return 2
 
     try:
         config = load_config(

--- a/tests/test_goal_cli.py
+++ b/tests/test_goal_cli.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+import json
+
+import pytest
+
+import wilfred.__main__ as wilfred_main
+
+
+class FakeOpenAIProvider:
+    calls = []
+
+    @classmethod
+    def from_environment(cls, *, model, environ=None):
+        cls.calls.append((model, dict(environ or {})))
+
+        def provider(message, system_prompt, tools):
+            return json.dumps(
+                {
+                    "tool_name": "wilfred_status",
+                    "arguments": {},
+                    "confidence": 1.0,
+                    "reason": "goal cli test",
+                }
+            )
+
+        return provider
+
+
+def run_cli(arguments, *, environ=None):
+    output = StringIO()
+    errors = StringIO()
+
+    with redirect_stdout(output), redirect_stderr(errors):
+        rc = wilfred_main.main(
+            arguments,
+            environ={} if environ is None else environ,
+        )
+
+    return rc, output.getvalue(), errors.getvalue()
+
+
+def test_goal_parser_has_no_api_key_option():
+    parser = wilfred_main.build_parser()
+
+    parsed = parser.parse_args(
+        [
+            "goal",
+            "what is your status?",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+            "--confirmed",
+        ]
+    )
+
+    assert parsed.command == "goal"
+    assert parsed.message == "what is your status?"
+    assert parsed.provider == "openai"
+    assert parsed.model == "test-model"
+    assert parsed.confirmed is True
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "goal",
+                "status",
+                "--provider",
+                "openai",
+                "--model",
+                "test-model",
+                "--api-key",
+                "forbidden",
+            ]
+        )
+
+
+def test_goal_uses_environment_provider_and_emits_result_json(
+    monkeypatch,
+):
+    FakeOpenAIProvider.calls = []
+
+    monkeypatch.setattr(
+        wilfred_main,
+        "OpenAIPlannerProvider",
+        FakeOpenAIProvider,
+        raising=False,
+    )
+
+    rc, output, errors = run_cli(
+        [
+            "goal",
+            "what is your status?",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+        ],
+        environ={
+            "WILFRED_OPENAI_API_KEY": "test-secret",
+        },
+    )
+
+    assert rc == 0
+    assert errors == ""
+
+    assert FakeOpenAIProvider.calls == [
+        (
+            "test-model",
+            {"WILFRED_OPENAI_API_KEY": "test-secret"},
+        )
+    ]
+
+    payload = json.loads(output)
+
+    assert payload["planning"]["status"] == "success"
+    assert (
+        payload["planning"]["plan"]["tool_name"]
+        == "wilfred_status"
+    )
+    assert payload["execution"]["status"] == "success"
+
+    assert "test-secret" not in output
+
+
+def test_goal_confirmation_is_explicit_cli_input(monkeypatch):
+    from wilfred.runtime import WilfredRuntime as RealRuntime
+
+    confirmations = []
+
+    class RecordingRuntime(RealRuntime):
+        def execute_goal(self, message, *, confirmed=False):
+            confirmations.append(confirmed)
+            return super().execute_goal(
+                message,
+                confirmed=confirmed,
+            )
+
+    monkeypatch.setattr(
+        wilfred_main,
+        "OpenAIPlannerProvider",
+        FakeOpenAIProvider,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        wilfred_main,
+        "WilfredRuntime",
+        RecordingRuntime,
+        raising=False,
+    )
+
+    environment = {
+        "WILFRED_OPENAI_API_KEY": "test-secret",
+    }
+
+    rc, _, _ = run_cli(
+        [
+            "goal",
+            "status",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+        ],
+        environ=environment,
+    )
+    assert rc == 0
+
+    rc, _, _ = run_cli(
+        [
+            "goal",
+            "status",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+            "--confirmed",
+        ],
+        environ=environment,
+    )
+    assert rc == 0
+
+    assert confirmations == [False, True]
+
+
+def test_goal_missing_key_is_clean_configuration_error():
+    rc, output, errors = run_cli(
+        [
+            "goal",
+            "status",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+        ],
+        environ={},
+    )
+
+    assert rc == 2
+    assert output == ""
+    assert "configuration error" in errors.lower()
+    assert "WILFRED_OPENAI_API_KEY" in errors
+    assert "Traceback" not in errors
+
+
+def test_goal_provider_configuration_error_is_clean(monkeypatch):
+    from wilfred.providers import OpenAIProviderConfigurationError
+
+    class BrokenProvider:
+        @classmethod
+        def from_environment(cls, **kwargs):
+            raise OpenAIProviderConfigurationError(
+                "OpenAI provider unavailable."
+            )
+
+    monkeypatch.setattr(
+        wilfred_main,
+        "OpenAIPlannerProvider",
+        BrokenProvider,
+    )
+
+    rc, output, errors = run_cli(
+        [
+            "goal",
+            "status",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+        ],
+        environ={"WILFRED_OPENAI_API_KEY": "test-secret"},
+    )
+
+    assert rc == 2
+    assert output == ""
+    assert errors == (
+        "wilfred: configuration error: "
+        "OpenAI provider unavailable.\n"
+    )
+    assert "test-secret" not in errors


### PR DESCRIPTION
## Summary

Add the public goal-oriented Wilfred CLI.

## Command

`wilfred goal "..." --provider openai --model MODEL [--confirmed]`

## Boundaries

- planner selects one validated ToolPlan per goal
- planner does not execute tools
- execution remains governed by ExecutionPolicy
- ACTION confirmation defaults to false
- only --confirmed supplies explicit CLI confirmation
- DANGEROUS remains denied by the default policy
- WILFRED_OPENAI_API_KEY remains environment-only
- RuntimeConfig is unchanged
- no API-key CLI or TOML option
- multi-tool planning chains are not introduced

## Errors

Provider configuration failures return a clean CLI configuration error with exit code 2 instead of a traceback.

## Verification

- goal CLI tests: 5 passed
- existing CLI tests: 3 passed
- full suite: 109 passed