### PR TITLE
WILF-035: add goal HTTP API

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It provides:
 - local SQLite persistence for completed workflow results;
 - a public plugin contract and loader;
 - a standalone command-line entrypoint;
+- an optional FastAPI HTTP transport for the Goal Runtime;
 - an example read-only plugin;
 - standalone identity and runtime configuration;
 - public distribution and clean-room tests.
@@ -64,6 +65,9 @@ composition API.
 See [Goal-oriented CLI](docs/goal-cli.md) for natural-language goal
 planning and execution from the command line.
 
+See [HTTP API](docs/http-api.md) for the optional FastAPI transport,
+loopback-only defaults, structured confirmation flow and security boundary.
+
 See [Provider latency acknowledgement](docs/provider-latency-acknowledgement.md)
 for optional pre-planning conversational feedback.
 
@@ -89,6 +93,7 @@ Wilfred currently provides:
 - provider-neutral planned execution backed by Butler Core;
 - a public goal-oriented `WilfredRuntime` composition API;
 - a goal-oriented CLI for provider-backed planning and execution;
+- an optional FastAPI transport for health, runtime, tools and goals;
 - an optional OpenAI BYOK planner provider;
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification without Alfred or another consumer.

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,8 +21,9 @@ Run the complete suite:
 .venv/bin/python -m pytest -q
 ~~~
 
-The `dev` extra contains development and packaging tools only.
-Normal Wilfred installations do not install them.
+The `dev` extra contains development, packaging and HTTP test tools.
+Normal Wilfred installations do not install them. Production HTTP support
+is available separately through the `http` extra.
 
 The suite includes the clean-room wheel test, which verifies that the
 public distribution works without another butler repository.

--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -1,0 +1,158 @@
+# HTTP API
+
+Wilfred provides an optional FastAPI transport for the existing
+`WilfredRuntime`. FastAPI supplies request validation, response schemas and an
+OpenAPI document; the transport does not reimplement planning or execution.
+
+## Installation
+
+HTTP dependencies are optional:
+
+```bash
+python -m pip install 'wilfred-butler[http]'
+```
+
+The built-in server command currently supports the optional OpenAI planner.
+Install both extras when using that provider:
+
+```bash
+python -m pip install 'wilfred-butler[http,openai]'
+```
+
+Provide the BYOK credential only through the environment:
+
+```bash
+export WILFRED_OPENAI_API_KEY='your-key-from-a-secret-store'
+wilfred api --provider openai --model MODEL
+```
+
+There is no API-key command-line option and the credential is not part of an
+HTTP request or response.
+
+## Network defaults
+
+The server binds to `127.0.0.1:8000` by default. It is therefore reachable
+only from the local machine unless the operator explicitly selects another
+bind address.
+
+CORS is not enabled. Uvicorn access logging is disabled by the Wilfred server
+command so query strings are not written to an access log.
+
+The transport does not include authentication, TLS termination or rate
+limiting. Do not bind it to a public interface without a separately managed
+authenticated reverse proxy, TLS and an explicit network policy.
+
+An embedding application can construct the transport directly:
+
+```python
+from wilfred.api import create_app
+
+app = create_app(runtime)
+```
+
+`create_app()` accepts an already configured `WilfredRuntime`, so this path is
+provider-neutral.
+
+## Endpoints
+
+### GET /health
+
+Returns transport liveness without calling a planner provider:
+
+```json
+{"status": "ok"}
+```
+
+### GET /v1/runtime
+
+Returns credential-free runtime metadata and the registered tool count.
+
+### GET /v1/tools
+
+Returns deterministic public tool descriptions, including parameter schemas
+and permissions. Python handlers are never exposed.
+
+### POST /v1/goals
+
+Delegates directly to `WilfredRuntime.execute_goal()`.
+
+```json
+{
+  "message": "what is your status?",
+  "confirmed": false
+}
+```
+
+`message` is required. `confirmed` is optional, defaults to `false` and must be
+a JSON boolean.
+
+The response preserves the shared structured planning and execution result:
+
+```json
+{
+  "planning": {
+    "status": "success",
+    "duration_ms": 1.0,
+    "plan": {
+      "tool_name": "wilfred_status",
+      "arguments": {},
+      "confidence": 1.0,
+      "reason": "Read runtime status."
+    },
+    "model": null,
+    "error_code": null,
+    "error_message": null,
+    "validation_errors": []
+  },
+  "execution": {
+    "execution_id": "generated-identifier",
+    "tool_name": "wilfred_status",
+    "status": "success",
+    "duration_ms": 1.0,
+    "permission": "READ",
+    "value": {
+      "status": "ok"
+    },
+    "error": null,
+    "validation_errors": []
+  }
+}
+```
+
+## Confirmation boundary
+
+The planner cannot grant confirmation. If an `ACTION` requires approval, a
+request with the default `confirmed: false` returns an execution status of
+`confirmation_required`.
+
+Only after obtaining confirmation outside the planner may a client repeat the
+goal with:
+
+```json
+{
+  "message": "perform the action",
+  "confirmed": true
+}
+```
+
+`DANGEROUS` tools remain subject to `ExecutionPolicy`; confirmation does not
+override the default dangerous-tool denial.
+
+## Errors and secret handling
+
+Planner and Execution Engine failures remain structured inside the normal goal
+response. Request validation failures use HTTP 422 with an `invalid_request`
+code. Validation responses omit received values instead of echoing the request
+body. Unexpected runtime failures use HTTP 500 with a generic `runtime_error`
+message.
+
+The built-in command redacts the configured provider credential from nested
+goal results. Values under common sensitive keys such as `api_key`, `password`,
+`secret` and `token` are also redacted. Plugins and embedding applications must
+still avoid placing credentials in tool schemas, results or exception text.
+
+## Scope
+
+This transport does not add Home Assistant entities, household configuration,
+background jobs or a multi-step planner. Those remain separate public
+integration tasks.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -80,6 +80,25 @@ The module entrypoint is equivalent:
 python -m wilfred
 ```
 
+## Optional HTTP API
+
+The base installation does not install an HTTP server. Install Wilfred with
+the `http` extra to add the FastAPI transport and Uvicorn:
+
+```bash
+python -m pip install --no-build-isolation '.[http]'
+```
+
+The HTTP transport needs a configured planner provider. For the optional
+OpenAI provider, install both extras:
+
+```bash
+python -m pip install --no-build-isolation '.[http,openai]'
+```
+
+See [HTTP API](http-api.md) for startup, endpoints, confirmation handling and
+the network security boundary.
+
 ## Verify the public plugin contract
 
 Wilfred includes a harmless read-only example plugin named `demo.echo`.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -37,13 +37,23 @@ native Wilfred tools.
 
 `tool_names()` exposes the resulting deterministic registry contents.
 
+`describe_runtime()` and `describe_tools()` expose credential-free metadata
+for transports. Tool handlers themselves are never included.
+
+## Transports
+
+The command-line and optional FastAPI transports both delegate goal handling
+to `execute_goal()`. They use the same `PlannedExecutionResult.to_dict()`
+representation, so neither transport duplicates planning, execution or
+confirmation policy.
+
 ## Scope
 
 `WilfredRuntime` does not provide:
 
 - a concrete AI provider;
 - provider credentials or BYOK;
-- a goal CLI command;
+- transport authentication or public-network exposure;
 - Home Assistant integration;
 - background workers, queues, schedulers or retries.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,18 @@ where = ["src"]
 openai = [
     "openai>=2.53,<3",
 ]
+http = [
+    "fastapi>=0.115,<1",
+    "pydantic>=2.9,<3",
+    "uvicorn>=0.34,<1",
+]
 dev = [
+    "fastapi>=0.115,<1",
+    "httpx>=0.28,<1",
+    "httpx2>=2,<3",
+    "pydantic>=2.9,<3",
     "pytest>=9,<10",
     "setuptools>=68",
+    "uvicorn>=0.34,<1",
     "wheel>=0.45",
 ]

--- a/src/wilfred/__main__.py
+++ b/src/wilfred/__main__.py
@@ -22,6 +22,30 @@ from wilfred.registry import ToolRegistry
 from wilfred.runtime import WilfredRuntime
 
 
+DEFAULT_API_HOST = "127.0.0.1"
+DEFAULT_API_PORT = 8000
+
+
+class HTTPAPIConfigurationError(ValueError):
+    """Raised when the optional HTTP runtime cannot start."""
+
+
+def _api_port(value: str) -> int:
+    try:
+        port = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "port must be an integer"
+        ) from exc
+
+    if not 1 <= port <= 65535:
+        raise argparse.ArgumentTypeError(
+            "port must be between 1 and 65535"
+        )
+
+    return port
+
+
 def runtime_status(
     config: RuntimeConfig | None = None,
 ) -> dict[str, str]:
@@ -105,6 +129,39 @@ def build_parser() -> argparse.ArgumentParser:
         help="Explicitly confirm ACTION execution.",
     )
 
+    api = commands.add_parser(
+        "api",
+        help="Serve the goal runtime through the optional HTTP API.",
+        description=(
+            "Serve the goal runtime through the optional HTTP API."
+        ),
+    )
+    api.add_argument(
+        "--provider",
+        choices=("openai",),
+        required=True,
+        help="Planner provider.",
+    )
+    api.add_argument(
+        "--model",
+        required=True,
+        help="Provider model identifier.",
+    )
+    api.add_argument(
+        "--host",
+        default=DEFAULT_API_HOST,
+        help=(
+            "HTTP bind address. Defaults to the loopback-only "
+            f"address {DEFAULT_API_HOST}."
+        ),
+    )
+    api.add_argument(
+        "--port",
+        type=_api_port,
+        default=DEFAULT_API_PORT,
+        help=f"HTTP port. Defaults to {DEFAULT_API_PORT}.",
+    )
+
     return parser
 
 
@@ -171,46 +228,68 @@ def run_goal_command(
         confirmed=confirmed,
     )
 
-    plan = result.planning.plan
-
-    planning = {
-        "status": result.planning.status.value,
-        "duration_ms": result.planning.duration_ms,
-        "plan": (
-            None
-            if plan is None
-            else {
-                "tool_name": plan.tool_name,
-                "arguments": dict(plan.arguments),
-                "confidence": plan.confidence,
-                "reason": plan.reason,
-            }
-        ),
-        "model": result.planning.model,
-        "error_code": result.planning.error_code,
-        "error_message": result.planning.error_message,
-        "validation_errors": [
-            str(item)
-            for item in result.planning.validation_errors
-        ],
-    }
-
-    payload = {
-        "planning": planning,
-        "execution": (
-            None
-            if result.execution is None
-            else result.execution.to_dict()
-        ),
-    }
-
     print(
         json.dumps(
-            payload,
+            result.to_dict(),
             ensure_ascii=False,
             sort_keys=True,
         )
     )
+
+    return 0
+
+
+def run_api_command(
+    *,
+    provider_name: str,
+    model: str,
+    host: str,
+    port: int,
+    environ: Mapping[str, str],
+) -> int:
+    try:
+        from wilfred.api import (
+            HTTPAPIUnavailableError,
+            serve_api,
+        )
+    except (ImportError, RuntimeError) as exc:
+        raise HTTPAPIConfigurationError(
+            "HTTP API support requires the optional "
+            "'http' dependencies."
+        ) from exc
+
+    if provider_name != "openai":
+        raise ValueError(
+            f"Unsupported planner provider: {provider_name}"
+        )
+
+    provider = OpenAIPlannerProvider.from_environment(
+        model=model,
+        environ=environ,
+    )
+
+    runtime = WilfredRuntime(
+        provider=provider,
+        system_prompt=(
+            "Select the appropriate Wilfred tool for the "
+            "user's goal using only the available tools."
+        ),
+    )
+
+    secret = environ.get(
+        "WILFRED_OPENAI_API_KEY",
+        "",
+    ).strip()
+
+    try:
+        serve_api(
+            runtime,
+            host=host,
+            port=port,
+            sensitive_values=(secret,),
+        )
+    except HTTPAPIUnavailableError as exc:
+        raise HTTPAPIConfigurationError(str(exc)) from exc
 
     return 0
 
@@ -242,6 +321,31 @@ def main(
                 environ=effective_environment,
             )
         except OpenAIProviderConfigurationError as exc:
+            print(
+                f"wilfred: configuration error: {exc}",
+                file=sys.stderr,
+            )
+            return 2
+
+    if arguments.command == "api":
+        effective_environment = (
+            os.environ
+            if environ is None
+            else environ
+        )
+
+        try:
+            return run_api_command(
+                provider_name=arguments.provider,
+                model=arguments.model,
+                host=arguments.host,
+                port=arguments.port,
+                environ=effective_environment,
+            )
+        except (
+            HTTPAPIConfigurationError,
+            OpenAIProviderConfigurationError,
+        ) as exc:
             print(
                 f"wilfred: configuration error: {exc}",
                 file=sys.stderr,

--- a/src/wilfred/api.py
+++ b/src/wilfred/api.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, Literal
+
+
+class HTTPAPIUnavailableError(RuntimeError):
+    """Raised when optional HTTP dependencies are unavailable."""
+
+
+try:
+    from fastapi import FastAPI
+    from fastapi.encoders import jsonable_encoder
+    from fastapi.exceptions import RequestValidationError
+    from fastapi.responses import JSONResponse
+    from pydantic import BaseModel, ConfigDict, Field
+except ModuleNotFoundError as exc:
+    raise HTTPAPIUnavailableError(
+        "HTTP API support requires 'wilfred-butler[http]'."
+    ) from exc
+
+from wilfred import __version__
+from wilfred.runtime import WilfredRuntime
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+MAX_GOAL_LENGTH = 10_000
+REDACTED = "[REDACTED]"
+
+_SENSITIVE_KEYS = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "authorization",
+        "password",
+        "secret",
+        "token",
+    }
+)
+
+
+class HealthResponse(BaseModel):
+    status: Literal["ok"]
+
+
+class RuntimeResponse(BaseModel):
+    name: str
+    status: Literal["ok"]
+    version: str
+    runtime: str
+    tool_count: int
+
+
+class ToolResponse(BaseModel):
+    name: str
+    description: str
+    category: str
+    permission: str
+    parameters: dict[str, Any]
+
+
+class ToolsResponse(BaseModel):
+    tools: list[ToolResponse]
+
+
+class GoalRequest(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+        str_strip_whitespace=True,
+    )
+
+    message: str = Field(
+        min_length=1,
+        max_length=MAX_GOAL_LENGTH,
+    )
+    confirmed: bool = Field(
+        default=False,
+        strict=True,
+    )
+
+
+class ToolPlanResponse(BaseModel):
+    tool_name: str | None
+    arguments: dict[str, Any]
+    confidence: float
+    reason: str
+
+
+class PlanningResponse(BaseModel):
+    status: str
+    duration_ms: float
+    plan: ToolPlanResponse | None
+    model: str | None
+    error_code: str | None
+    error_message: str | None
+    validation_errors: list[str]
+
+
+class ResultErrorResponse(BaseModel):
+    code: str
+    message: str | None
+
+
+class ExecutionResponse(BaseModel):
+    execution_id: str
+    tool_name: str
+    status: str
+    duration_ms: float
+    permission: str | None
+    value: Any = None
+    error: ResultErrorResponse | None
+    validation_errors: list[str]
+
+
+class GoalResponse(BaseModel):
+    planning: PlanningResponse
+    execution: ExecutionResponse | None
+
+
+class ValidationIssueResponse(BaseModel):
+    location: list[str | int]
+    code: str
+    message: str
+
+
+class APIErrorDetailResponse(BaseModel):
+    code: str
+    message: str
+    validation_errors: list[ValidationIssueResponse] = Field(
+        default_factory=list
+    )
+
+
+class APIErrorResponse(BaseModel):
+    error: APIErrorDetailResponse
+
+
+def _key_is_sensitive(key: object) -> bool:
+    normalized = str(key).strip().lower().replace("-", "_")
+
+    return (
+        normalized in _SENSITIVE_KEYS
+        or normalized.endswith("_api_key")
+        or normalized.endswith("_password")
+        or normalized.endswith("_secret")
+        or normalized.endswith("_token")
+    )
+
+
+def _sanitize(
+    value: Any,
+    *,
+    sensitive_values: tuple[str, ...],
+) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            key: (
+                REDACTED
+                if _key_is_sensitive(key)
+                else _sanitize(
+                    item,
+                    sensitive_values=sensitive_values,
+                )
+            )
+            for key, item in value.items()
+        }
+
+    if isinstance(value, list):
+        return [
+            _sanitize(
+                item,
+                sensitive_values=sensitive_values,
+            )
+            for item in value
+        ]
+
+    if isinstance(value, tuple):
+        return [
+            _sanitize(
+                item,
+                sensitive_values=sensitive_values,
+            )
+            for item in value
+        ]
+
+    if isinstance(value, str):
+        sanitized = value
+
+        for secret in sensitive_values:
+            sanitized = sanitized.replace(secret, REDACTED)
+
+        return sanitized
+
+    return value
+
+
+def _resolved_sensitive_values(
+    values: Iterable[str],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                value
+                for item in values
+                if (value := item.strip())
+            },
+            key=len,
+            reverse=True,
+        )
+    )
+
+
+def create_app(
+    runtime: WilfredRuntime,
+    *,
+    sensitive_values: Iterable[str] = (),
+) -> FastAPI:
+    """Create the optional FastAPI transport for a Goal Runtime."""
+
+    secrets = _resolved_sensitive_values(sensitive_values)
+
+    app = FastAPI(
+        title="Wilfred HTTP API",
+        version=__version__,
+        description=(
+            "Provider-neutral HTTP transport for the Wilfred "
+            "Goal Runtime."
+        ),
+    )
+
+    @app.exception_handler(RequestValidationError)
+    async def request_validation_error(
+        request: object,
+        error: RequestValidationError,
+    ) -> JSONResponse:
+        del request
+
+        issues = [
+            {
+                "location": list(issue.get("loc", ())),
+                "code": str(issue.get("type", "invalid")),
+                "message": str(
+                    issue.get("msg", "Invalid request value.")
+                ),
+            }
+            for issue in error.errors()
+        ]
+
+        return JSONResponse(
+            status_code=422,
+            content={
+                "error": {
+                    "code": "invalid_request",
+                    "message": "Request validation failed.",
+                    "validation_errors": issues,
+                }
+            },
+        )
+
+    @app.get(
+        "/health",
+        response_model=HealthResponse,
+        tags=["system"],
+    )
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get(
+        "/v1/runtime",
+        response_model=RuntimeResponse,
+        tags=["runtime"],
+    )
+    def runtime_info() -> dict[str, object]:
+        return runtime.describe_runtime()
+
+    @app.get(
+        "/v1/tools",
+        response_model=ToolsResponse,
+        tags=["runtime"],
+    )
+    def tools() -> dict[str, object]:
+        return {"tools": runtime.describe_tools()}
+
+    @app.post(
+        "/v1/goals",
+        response_model=GoalResponse,
+        responses={
+            422: {"model": APIErrorResponse},
+            500: {"model": APIErrorResponse},
+        },
+        tags=["goals"],
+    )
+    def execute_goal(request: GoalRequest) -> Any:
+        try:
+            result = runtime.execute_goal(
+                request.message,
+                confirmed=request.confirmed,
+            )
+            payload = _sanitize(
+                result.to_dict(),
+                sensitive_values=secrets,
+            )
+
+            return jsonable_encoder(payload)
+        except Exception:
+            return JSONResponse(
+                status_code=500,
+                content={
+                    "error": {
+                        "code": "runtime_error",
+                        "message": "Goal execution failed.",
+                        "validation_errors": [],
+                    }
+                },
+            )
+
+    return app
+
+
+def serve_api(
+    runtime: WilfredRuntime,
+    *,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    sensitive_values: Iterable[str] = (),
+) -> None:
+    """Serve a configured runtime without public-network defaults."""
+
+    try:
+        import uvicorn
+    except ModuleNotFoundError as exc:
+        raise HTTPAPIUnavailableError(
+            "HTTP API support requires 'wilfred-butler[http]'."
+        ) from exc
+
+    app = create_app(
+        runtime,
+        sensitive_values=sensitive_values,
+    )
+
+    uvicorn.run(
+        app,
+        host=host,
+        port=port,
+        access_log=False,
+    )
+
+
+__all__ = [
+    "DEFAULT_HOST",
+    "DEFAULT_PORT",
+    "GoalRequest",
+    "GoalResponse",
+    "HTTPAPIUnavailableError",
+    "create_app",
+    "serve_api",
+]

--- a/src/wilfred/native.py
+++ b/src/wilfred/native.py
@@ -19,7 +19,7 @@ def _runtime_status() -> dict[str, str]:
     }
 
 
-def _describe_tool(
+def describe_tool(
     tool: ToolDefinition,
 ) -> dict[str, Any]:
     return {
@@ -27,6 +27,7 @@ def _describe_tool(
         "description": tool.description,
         "category": tool.category,
         "permission": tool.permission.value,
+        "parameters": dict(tool.parameters),
     }
 
 
@@ -59,7 +60,7 @@ def register_native_tools(
 
         return {
             "tools": [
-                _describe_tool(tool)
+                describe_tool(tool)
                 for tool in tools
             ]
         }
@@ -81,3 +82,9 @@ def register_native_tools(
             permission=ToolPermission.READ,
         )
     )
+
+
+__all__ = [
+    "describe_tool",
+    "register_native_tools",
+]

--- a/src/wilfred/planning.py
+++ b/src/wilfred/planning.py
@@ -22,6 +22,41 @@ class PlannedExecutionResult:
     planning: PlannerResult
     execution: ExecutionResult | None = None
 
+    def to_dict(self) -> dict[str, object]:
+        """Return the shared CLI and HTTP representation."""
+
+        plan = self.planning.plan
+
+        planning = {
+            "status": self.planning.status.value,
+            "duration_ms": self.planning.duration_ms,
+            "plan": (
+                None
+                if plan is None
+                else {
+                    "tool_name": plan.tool_name,
+                    "arguments": dict(plan.arguments),
+                    "confidence": plan.confidence,
+                    "reason": plan.reason,
+                }
+            ),
+            "model": self.planning.model,
+            "error_code": self.planning.error_code,
+            "error_message": self.planning.error_message,
+            "validation_errors": list(
+                self.planning.validation_errors
+            ),
+        }
+
+        return {
+            "planning": planning,
+            "execution": (
+                None
+                if self.execution is None
+                else self.execution.to_dict()
+            ),
+        }
+
 
 class PlannedExecution:
     """

--- a/src/wilfred/runtime.py
+++ b/src/wilfred/runtime.py
@@ -7,7 +7,11 @@ from butler_core import (
     PlannerProvider,
 )
 
-from wilfred.native import register_native_tools
+from wilfred import __version__
+from wilfred.native import (
+    describe_tool,
+    register_native_tools,
+)
 from wilfred.output import (
     OutputAdapter,
     OutputKind,
@@ -58,6 +62,27 @@ class WilfredRuntime:
 
     def tool_names(self) -> list[str]:
         return self._registry.names()
+
+    def describe_runtime(self) -> dict[str, object]:
+        """Return public, credential-free runtime metadata."""
+
+        return {
+            "name": "Wilfred",
+            "status": "ok",
+            "version": __version__,
+            "runtime": "goal-runtime",
+            "tool_count": len(self._registry.names()),
+        }
+
+    def describe_tools(self) -> list[dict[str, object]]:
+        """Return deterministic public tool descriptions."""
+
+        tools = sorted(
+            self._registry.list_tools(),
+            key=lambda item: item.name,
+        )
+
+        return [describe_tool(tool) for tool in tools]
 
     def execute_goal(
         self,

--- a/tests/test_development_environment.py
+++ b/tests/test_development_environment.py
@@ -46,8 +46,41 @@ class DevelopmentEnvironmentTests(unittest.TestCase):
 
         self.assertEqual(
             names,
-            {"pytest", "setuptools", "wheel"},
+            {
+                "fastapi",
+                "httpx",
+                "httpx2",
+                "pydantic",
+                "pytest",
+                "setuptools",
+                "uvicorn",
+                "wheel",
+            },
         )
+
+    def test_http_extra_is_optional_and_complete(self) -> None:
+        project = self.load_project()
+        requirements = project[
+            "optional-dependencies"
+        ]["http"]
+
+        names = {
+            requirement_name(item)
+            for item in requirements
+        }
+
+        self.assertEqual(
+            names,
+            {"fastapi", "pydantic", "uvicorn"},
+        )
+
+        runtime_names = {
+            requirement_name(item)
+            for item in project["dependencies"]
+        }
+
+        self.assertNotIn("fastapi", runtime_names)
+        self.assertNotIn("uvicorn", runtime_names)
 
     def test_runtime_dependency_is_butler_core(self) -> None:
         dependencies = self.load_project()["dependencies"]

--- a/tests/test_distribution_clean_room.py
+++ b/tests/test_distribution_clean_room.py
@@ -173,6 +173,16 @@ if importlib.util.find_spec("butler_core") is None:
         "Butler Core is missing from the clean environment."
     )
 
+if importlib.util.find_spec("fastapi") is not None:
+    raise RuntimeError(
+        "FastAPI leaked into the base Wilfred installation."
+    )
+
+if importlib.util.find_spec("uvicorn") is not None:
+    raise RuntimeError(
+        "Uvicorn leaked into the base Wilfred installation."
+    )
+
 registry = ToolRegistry()
 plugins = discover_plugins(
     ["wilfred.plugins.demo_echo"]
@@ -298,6 +308,21 @@ print(
             self.assertEqual(
                 status["runtime"],
                 "standalone-bootstrap",
+            )
+
+            api_help = _run(
+                [
+                    str(clean_wilfred),
+                    "api",
+                    "--help",
+                ],
+                cwd=lab,
+                environment=environment,
+            )
+
+            self.assertIn(
+                "optional HTTP API",
+                api_help.stdout,
             )
 
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -32,6 +32,52 @@ class WilfredDocumentationTests(unittest.TestCase):
             ),
             readme,
         )
+        self.assertIn(
+            "docs/http-api.md",
+            readme,
+        )
+
+    def test_http_api_guide_documents_security_contract(self) -> None:
+        guide = (
+            PROJECT_ROOT
+            / "docs"
+            / "http-api.md"
+        ).read_text(encoding="utf-8")
+
+        normalized = " ".join(guide.split())
+
+        for endpoint in (
+            "GET /health",
+            "GET /v1/runtime",
+            "GET /v1/tools",
+            "POST /v1/goals",
+        ):
+            self.assertIn(endpoint, guide)
+
+        self.assertIn(
+            "127.0.0.1",
+            guide,
+        )
+        self.assertIn(
+            "CORS is not enabled",
+            normalized,
+        )
+        self.assertIn(
+            "does not include authentication",
+            normalized,
+        )
+        self.assertIn(
+            "confirmed",
+            guide,
+        )
+        self.assertIn(
+            "confirmation_required",
+            guide,
+        )
+        self.assertNotIn(
+            "allow_origins=[\"*\"]",
+            guide,
+        )
 
     def test_installation_uses_execution_engine(self) -> None:
         installation = (

--- a/tests/test_goal_api_cli.py
+++ b/tests/test_goal_api_cli.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+
+import pytest
+
+import wilfred.__main__ as wilfred_main
+import wilfred.api as wilfred_api
+
+
+SECRET = "api-cli-secret"
+
+
+class FakeOpenAIProvider:
+    calls = []
+
+    @classmethod
+    def from_environment(cls, *, model, environ=None):
+        cls.calls.append((model, dict(environ or {})))
+
+        return lambda message, system_prompt, tools: "{}"
+
+
+def run_cli(arguments, *, environ=None):
+    output = StringIO()
+    errors = StringIO()
+
+    with redirect_stdout(output), redirect_stderr(errors):
+        rc = wilfred_main.main(
+            arguments,
+            environ={} if environ is None else environ,
+        )
+
+    return rc, output.getvalue(), errors.getvalue()
+
+
+def test_api_parser_is_loopback_only_and_has_no_key_option():
+    parser = wilfred_main.build_parser()
+
+    parsed = parser.parse_args(
+        [
+            "api",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+        ]
+    )
+
+    assert parsed.host == "127.0.0.1"
+    assert parsed.port == 8000
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "api",
+                "--provider",
+                "openai",
+                "--model",
+                "test-model",
+                "--api-key",
+                SECRET,
+            ]
+        )
+
+
+def test_api_command_builds_runtime_and_serves_it(monkeypatch):
+    FakeOpenAIProvider.calls = []
+    calls = []
+
+    monkeypatch.setattr(
+        wilfred_main,
+        "OpenAIPlannerProvider",
+        FakeOpenAIProvider,
+    )
+    monkeypatch.setattr(
+        wilfred_api,
+        "serve_api",
+        lambda runtime, **kwargs: calls.append(
+            (runtime, kwargs)
+        ),
+    )
+
+    rc, output, errors = run_cli(
+        [
+            "api",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+        ],
+        environ={"WILFRED_OPENAI_API_KEY": SECRET},
+    )
+
+    assert rc == 0
+    assert output == ""
+    assert errors == ""
+    assert FakeOpenAIProvider.calls == [
+        (
+            "test-model",
+            {"WILFRED_OPENAI_API_KEY": SECRET},
+        )
+    ]
+    assert len(calls) == 1
+
+    runtime, options = calls[0]
+
+    assert isinstance(runtime, wilfred_main.WilfredRuntime)
+    assert options == {
+        "host": "127.0.0.1",
+        "port": 8000,
+        "sensitive_values": (SECRET,),
+    }
+
+
+def test_api_missing_key_is_clean_configuration_error(monkeypatch):
+    called = False
+
+    def fail_if_called(*args, **kwargs):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        wilfred_api,
+        "serve_api",
+        fail_if_called,
+    )
+
+    rc, output, errors = run_cli(
+        [
+            "api",
+            "--provider",
+            "openai",
+            "--model",
+            "test-model",
+        ],
+        environ={},
+    )
+
+    assert rc == 2
+    assert output == ""
+    assert "configuration error" in errors.lower()
+    assert "WILFRED_OPENAI_API_KEY" in errors
+    assert "Traceback" not in errors
+    assert called is False

--- a/tests/test_http_api.py
+++ b/tests/test_http_api.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+import pytest
+
+from wilfred.api import (
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    REDACTED,
+    create_app,
+    serve_api,
+)
+from wilfred.models import ToolDefinition, ToolPermission
+from wilfred.plugins import PluginDefinition
+from wilfred.runtime import WilfredRuntime
+
+
+SECRET = "test-secret-never-return"
+
+
+def _provider(tool_name, arguments=None):
+    def provider(message, system_prompt, tools):
+        return json.dumps(
+            {
+                "tool_name": tool_name,
+                "arguments": arguments or {},
+                "confidence": 1.0,
+                "reason": "deterministic API test",
+            }
+        )
+
+    return provider
+
+
+def _runtime(*, tool_name="wilfred_status", plugins=()):
+    return WilfredRuntime(
+        provider=_provider(tool_name),
+        system_prompt="Test Wilfred HTTP API.",
+        plugins=plugins,
+    )
+
+
+def test_health_runtime_tools_and_openapi_are_exposed():
+    client = TestClient(create_app(_runtime()))
+
+    assert client.get("/health").json() == {"status": "ok"}
+
+    runtime = client.get("/v1/runtime")
+
+    assert runtime.status_code == 200
+    assert runtime.json()["runtime"] == "goal-runtime"
+    assert runtime.json()["tool_count"] == 2
+
+    tools = client.get("/v1/tools")
+
+    assert tools.status_code == 200
+    assert [
+        tool["name"]
+        for tool in tools.json()["tools"]
+    ] == [
+        "wilfred_status",
+        "wilfred_tools",
+    ]
+
+    paths = client.get("/openapi.json").json()["paths"]
+
+    assert set(paths) >= {
+        "/health",
+        "/v1/runtime",
+        "/v1/tools",
+        "/v1/goals",
+    }
+
+
+def test_goal_endpoint_reuses_structured_goal_runtime_result():
+    client = TestClient(create_app(_runtime()))
+
+    response = client.post(
+        "/v1/goals",
+        json={"message": "what is your status?"},
+    )
+
+    assert response.status_code == 200
+
+    payload = response.json()
+
+    assert payload["planning"]["status"] == "success"
+    assert (
+        payload["planning"]["plan"]["tool_name"]
+        == "wilfred_status"
+    )
+    assert payload["execution"]["status"] == "success"
+    assert payload["execution"]["permission"] == "READ"
+    assert payload["execution"]["execution_id"]
+
+
+def test_action_confirmation_is_explicit_http_input():
+    plugin = PluginDefinition(
+        name="test.action",
+        register=lambda registry: registry.register(
+            ToolDefinition(
+                name="test_action",
+                description="Perform a test action.",
+                handler=lambda: {"done": True},
+                permission=ToolPermission.ACTION,
+            )
+        ),
+    )
+
+    client = TestClient(
+        create_app(
+            _runtime(
+                tool_name="test_action",
+                plugins=[plugin],
+            )
+        )
+    )
+
+    pending = client.post(
+        "/v1/goals",
+        json={"message": "do the action"},
+    )
+
+    assert pending.status_code == 200
+    assert (
+        pending.json()["execution"]["status"]
+        == "confirmation_required"
+    )
+
+    confirmed = client.post(
+        "/v1/goals",
+        json={
+            "message": "do the action",
+            "confirmed": True,
+        },
+    )
+
+    assert confirmed.status_code == 200
+    assert confirmed.json()["execution"]["status"] == "success"
+    assert confirmed.json()["execution"]["value"] == {
+        "done": True
+    }
+
+
+def test_request_validation_never_echoes_received_values():
+    client = TestClient(create_app(_runtime()))
+
+    response = client.post(
+        "/v1/goals",
+        json={
+            "message": " ",
+            "api_key": SECRET,
+        },
+    )
+
+    assert response.status_code == 422
+    assert response.json()["error"]["code"] == "invalid_request"
+    assert SECRET not in response.text
+    assert all(
+        "input" not in issue
+        for issue in response.json()["error"][
+            "validation_errors"
+        ]
+    )
+
+
+def test_goal_result_redacts_sensitive_keys_and_values():
+    plugin = PluginDefinition(
+        name="test.secret",
+        register=lambda registry: registry.register(
+            ToolDefinition(
+                name="test_secret",
+                description="Return unsafe test data.",
+                handler=lambda: {
+                    "api_key": SECRET,
+                    "message": f"provider said {SECRET}",
+                },
+                permission=ToolPermission.READ,
+            )
+        ),
+    )
+
+    client = TestClient(
+        create_app(
+            _runtime(
+                tool_name="test_secret",
+                plugins=[plugin],
+            ),
+            sensitive_values=(SECRET,),
+        )
+    )
+
+    response = client.post(
+        "/v1/goals",
+        json={"message": "read test data"},
+    )
+
+    assert response.status_code == 200
+    assert SECRET not in response.text
+
+    value = response.json()["execution"]["value"]
+
+    assert value["api_key"] == REDACTED
+    assert value["message"] == f"provider said {REDACTED}"
+
+
+def test_unexpected_runtime_error_is_generic_and_not_logged(
+    caplog,
+    capsys,
+):
+    class BrokenRuntime:
+        def describe_runtime(self):
+            return {
+                "name": "Wilfred",
+                "status": "ok",
+                "version": "test",
+                "runtime": "goal-runtime",
+                "tool_count": 0,
+            }
+
+        def describe_tools(self):
+            return []
+
+        def execute_goal(self, message, *, confirmed=False):
+            raise RuntimeError(SECRET)
+
+    client = TestClient(
+        create_app(
+            BrokenRuntime(),
+            sensitive_values=(SECRET,),
+        )
+    )
+
+    response = client.post(
+        "/v1/goals",
+        json={"message": "fail safely"},
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "code": "runtime_error",
+            "message": "Goal execution failed.",
+            "validation_errors": [],
+        }
+    }
+    assert SECRET not in response.text
+    assert SECRET not in caplog.text
+
+    captured = capsys.readouterr()
+
+    assert SECRET not in captured.out
+    assert SECRET not in captured.err
+
+
+def test_cors_is_not_enabled_by_default():
+    client = TestClient(create_app(_runtime()))
+
+    response = client.get(
+        "/health",
+        headers={"Origin": "https://example.invalid"},
+    )
+
+    assert "access-control-allow-origin" not in response.headers
+
+    preflight = client.options(
+        "/v1/goals",
+        headers={
+            "Origin": "https://example.invalid",
+            "Access-Control-Request-Method": "POST",
+        },
+    )
+
+    assert "access-control-allow-origin" not in preflight.headers
+
+
+def test_server_defaults_to_loopback_without_access_log(monkeypatch):
+    captured = {}
+
+    def fake_run(app, **kwargs):
+        captured["app"] = app
+        captured.update(kwargs)
+
+    monkeypatch.setattr("uvicorn.run", fake_run)
+
+    serve_api(_runtime())
+
+    assert captured["host"] == DEFAULT_HOST == "127.0.0.1"
+    assert captured["port"] == DEFAULT_PORT == 8000
+    assert captured["access_log"] is False
+    assert captured["app"].title == "Wilfred HTTP API"
+
+
+def test_confirmed_requires_a_real_boolean():
+    client = TestClient(create_app(_runtime()))
+
+    response = client.post(
+        "/v1/goals",
+        json={
+            "message": "status",
+            "confirmed": "yes",
+        },
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("port", ["0", "65536", "not-a-port"])
+def test_api_cli_rejects_invalid_ports(port):
+    from wilfred.__main__ import build_parser
+
+    parser = build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "api",
+                "--provider",
+                "openai",
+                "--model",
+                "test-model",
+                "--port",
+                port,
+            ]
+        )

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -76,3 +76,8 @@ def test_wilfred_tools_introspects_registry() -> None:
         tool["category"] == "native"
         for tool in tools
     )
+
+    assert all(
+        tool["parameters"]["type"] == "object"
+        for tool in tools
+    )

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -35,6 +35,22 @@ def test_runtime_registers_native_tools():
         "wilfred_tools",
     ]
 
+    description = runtime.describe_runtime()
+
+    assert description["name"] == "Wilfred"
+    assert description["status"] == "ok"
+    assert description["runtime"] == "goal-runtime"
+    assert description["tool_count"] == 2
+
+    tools = runtime.describe_tools()
+
+    assert [tool["name"] for tool in tools] == [
+        "wilfred_status",
+        "wilfred_tools",
+    ]
+    assert all("handler" not in tool for tool in tools)
+    assert all("parameters" in tool for tool in tools)
+
 
 def test_runtime_loads_public_plugins():
     from wilfred.runtime import WilfredRuntime


### PR DESCRIPTION
## Summary

Adds the first HTTP API surface for Wilfred goal execution.

### Included

- new HTTP API module
- goal execution endpoint
- CLI support for serving the API
- runtime integration
- native/planning integration
- installation, runtime and API documentation
- clean-room and development-environment coverage
- dedicated HTTP API and goal CLI tests

## Architecture

The API remains a thin transport layer over Wilfred's existing runtime/planning/execution capabilities. It does not become a second orchestration core.

## Validation

- compilation passed
- full WILF-035 verification passed
- distribution/clean-room checks covered
- branch pushed and remote commit verified

Closes WILF-035.