### PR TITLE
docs(readme): keep private consumers out of public surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Wilfred currently provides:
 - an optional FastAPI transport for health, runtime, tools and goals;
 - an optional OpenAI BYOK planner provider;
 - provider-agnostic READ-ACTION-VERIFY workflows;
-- clean-room wheel verification without Alfred or another consumer.
+- clean-room wheel verification as a standalone distribution.
 
 The following capabilities are still under development and are not presented
 as available:
@@ -113,17 +113,12 @@ and Wilfred can demonstrate useful native behaviour.
 This repository contains only generic runtime components, contracts,
 documentation, tests and publishable plugins.
 
+Wilfred is documented and distributed as a standalone public product.
+Public interfaces and user-facing documentation do not assume knowledge of
+any private consumer deployment.
+
 Consumer-specific integrations, infrastructure details, credentials and
 operational configuration belong in separate repositories.
-
-## Project context boundary
-
-Wilfred and the private Alfred deployment use separate AI project contexts.
-Only reviewed, versioned, distribution-safe artifacts cross that boundary.
-
-See
-[ADR 0001: Separate Alfred and Wilfred project contexts](docs/adr/0001-chatgpt-project-boundary.md)
-for the ownership rules and publication checklist.
 
 ## Provider-agnostic output
 

--- a/tests/test_project_context_boundary.py
+++ b/tests/test_project_context_boundary.py
@@ -10,9 +10,11 @@ def test_boundary_adr_is_published() -> None:
     assert ADR.is_file()
 
 
-def test_readme_links_boundary_adr() -> None:
+def test_readme_presents_standalone_public_boundary() -> None:
     text = README.read_text(encoding="utf-8")
-    assert "docs/adr/0001-chatgpt-project-boundary.md" in text
+    assert "standalone public product" in text
+    assert "private consumer deployment" in text
+    assert "Alfred" not in text
 
 
 def test_boundary_defines_separate_ownership() -> None:


### PR DESCRIPTION
## Summary

Cleans the public README boundary so Wilfred is presented as a standalone public product.

## Changes

- removes direct references to private consumer deployments
- makes clean-room verification wording standalone
- keeps the public boundary generic and distribution-safe

## Validation

- documentation tests: 6 passed
- zero `Alfred` references in README.md
- diff scope: README.md only