### PR TITLE
Configured external plugin bootstrap [WILF-038]

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -205,3 +205,33 @@ From the activated virtual environment:
 ```bash
 python -m pip uninstall wilfred-butler
 ```
+
+## Configured external plugins
+
+The standalone goal runtime can load installed plugin factories without adding
+integration-specific code to Wilfred.
+
+A configured plugin factory uses the form:
+
+    package.module:factory
+
+For the official Home Assistant plugin:
+
+    wilfred_home_assistant.bootstrap:create_plugin_from_environment
+
+The factory can be selected explicitly:
+
+    wilfred api \
+      --plugin wilfred_home_assistant.bootstrap:create_plugin_from_environment \
+      --provider openai \
+      --model MODEL
+
+For containerized deployments the same value can be supplied through:
+
+    WILFRED_PLUGINS=wilfred_home_assistant.bootstrap:create_plugin_from_environment
+
+Multiple values in `WILFRED_PLUGINS` are comma-separated.
+
+Plugin factories receive the runtime environment and return a normal
+`PluginDefinition`. They do not bypass Wilfred registration, permissions,
+confirmation policy or execution.

--- a/src/wilfred/__main__.py
+++ b/src/wilfred/__main__.py
@@ -18,6 +18,7 @@ from wilfred.providers import (
     OpenAIPlannerProvider,
     OpenAIProviderConfigurationError,
 )
+from wilfred.plugins import discover_configured_plugins
 from wilfred.registry import ToolRegistry
 from wilfred.runtime import WilfredRuntime
 
@@ -44,6 +45,35 @@ def _api_port(value: str) -> int:
         )
 
     return port
+
+
+
+def _plugin_specs(
+    cli_values: Sequence[str],
+    environ: Mapping[str, str],
+) -> tuple[str, ...]:
+    environment_values = [
+        value.strip()
+        for value in environ.get(
+            "WILFRED_PLUGINS",
+            "",
+        ).split(",")
+        if value.strip()
+    ]
+
+    return tuple(
+        sorted(
+            {
+                value.strip()
+                for value in [
+                    *environment_values,
+                    *cli_values,
+                ]
+                if value.strip()
+            }
+        )
+    )
+
 
 
 def runtime_status(
@@ -124,6 +154,17 @@ def build_parser() -> argparse.ArgumentParser:
         help="Provider model identifier.",
     )
     goal.add_argument(
+        "--plugin",
+        action="append",
+        default=[],
+        metavar="MODULE:FACTORY",
+        help=(
+            "Load a configured plugin factory. "
+            "May be repeated."
+        ),
+    )
+
+    goal.add_argument(
         "--confirmed",
         action="store_true",
         help="Explicitly confirm ACTION execution.",
@@ -136,6 +177,17 @@ def build_parser() -> argparse.ArgumentParser:
             "Serve the goal runtime through the optional HTTP API."
         ),
     )
+    api.add_argument(
+        "--plugin",
+        action="append",
+        default=[],
+        metavar="MODULE:FACTORY",
+        help=(
+            "Load a configured plugin factory. "
+            "May be repeated."
+        ),
+    )
+
     api.add_argument(
         "--provider",
         choices=("openai",),
@@ -203,6 +255,7 @@ def run_goal_command(
     provider_name: str,
     model: str,
     confirmed: bool,
+    plugin_specs: Sequence[str],
     environ: Mapping[str, str],
 ) -> int:
     if provider_name != "openai":
@@ -215,8 +268,14 @@ def run_goal_command(
         environ=environ,
     )
 
+    plugins = discover_configured_plugins(
+        plugin_specs,
+        environ=environ,
+    )
+
     runtime = WilfredRuntime(
         provider=provider,
+        plugins=plugins,
         system_prompt=(
             "Select the appropriate Wilfred tool for the "
             "user's goal using only the available tools."
@@ -245,6 +304,7 @@ def run_api_command(
     model: str,
     host: str,
     port: int,
+    plugin_specs: Sequence[str],
     environ: Mapping[str, str],
 ) -> int:
     try:
@@ -268,8 +328,14 @@ def run_api_command(
         environ=environ,
     )
 
+    plugins = discover_configured_plugins(
+        plugin_specs,
+        environ=environ,
+    )
+
     runtime = WilfredRuntime(
         provider=provider,
+        plugins=plugins,
         system_prompt=(
             "Select the appropriate Wilfred tool for the "
             "user's goal using only the available tools."
@@ -318,6 +384,10 @@ def main(
                 provider_name=arguments.provider,
                 model=arguments.model,
                 confirmed=arguments.confirmed,
+                plugin_specs=_plugin_specs(
+                    arguments.plugin,
+                    effective_environment,
+                ),
                 environ=effective_environment,
             )
         except OpenAIProviderConfigurationError as exc:
@@ -340,6 +410,10 @@ def main(
                 model=arguments.model,
                 host=arguments.host,
                 port=arguments.port,
+                plugin_specs=_plugin_specs(
+                    arguments.plugin,
+                    effective_environment,
+                ),
                 environ=effective_environment,
             )
         except (

--- a/src/wilfred/plugins/__init__.py
+++ b/src/wilfred/plugins/__init__.py
@@ -5,6 +5,7 @@ from wilfred.plugins.contracts import (
     PluginLoadResult,
 )
 from wilfred.plugins.loader import (
+    discover_configured_plugins,
     discover_plugins,
     load_plugin,
     load_plugins,
@@ -14,6 +15,7 @@ from wilfred.plugins.loader import (
 __all__ = [
     "PluginDefinition",
     "PluginLoadResult",
+    "discover_configured_plugins",
     "discover_plugins",
     "load_plugin",
     "load_plugins",

--- a/src/wilfred/plugins/loader.py
+++ b/src/wilfred/plugins/loader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from importlib import import_module
 from types import ModuleType
 
@@ -50,6 +50,98 @@ def discover_plugins(
         plugins,
         key=lambda plugin: plugin.name,
     )
+
+
+
+def _configured_plugin_from_spec(
+    spec: str,
+    *,
+    environ: Mapping[str, str],
+) -> PluginDefinition:
+    module_name, separator, attribute = spec.partition(":")
+
+    module_name = module_name.strip()
+    attribute = attribute.strip()
+
+    if (
+        separator != ":"
+        or not module_name
+        or not attribute
+    ):
+        raise ValueError(
+            "Configured plugin specification must use "
+            "'module:factory' format."
+        )
+
+    module = import_module(module_name)
+
+    factory = getattr(
+        module,
+        attribute,
+        None,
+    )
+
+    if not callable(factory):
+        raise TypeError(
+            f"Configured plugin factory {spec!r} "
+            "must be callable."
+        )
+
+    plugin = factory(environ)
+
+    if not isinstance(
+        plugin,
+        PluginDefinition,
+    ):
+        raise TypeError(
+            f"Configured plugin factory {spec!r} "
+            "must return PluginDefinition."
+        )
+
+    return plugin
+
+
+def discover_configured_plugins(
+    specs: Iterable[str],
+    *,
+    environ: Mapping[str, str],
+) -> list[PluginDefinition]:
+    plugins = [
+        _configured_plugin_from_spec(
+            spec,
+            environ=environ,
+        )
+        for spec in sorted(
+            {
+                value.strip()
+                for value in specs
+                if value.strip()
+            }
+        )
+    ]
+
+    names = [
+        plugin.name
+        for plugin in plugins
+    ]
+
+    if len(names) != len(set(names)):
+        duplicates = sorted(
+            name
+            for name in set(names)
+            if names.count(name) > 1
+        )
+
+        raise ValueError(
+            "Duplicate plugin names: "
+            f"{', '.join(duplicates)}"
+        )
+
+    return sorted(
+        plugins,
+        key=lambda plugin: plugin.name,
+    )
+
 
 
 def load_plugin(

--- a/tests/test_configured_plugin_bootstrap.py
+++ b/tests/test_configured_plugin_bootstrap.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+from wilfred import ToolDefinition, ToolPermission
+from wilfred.plugins import (
+    discover_configured_plugins,
+)
+
+
+def write_factory(
+    directory: Path,
+    *,
+    return_plugin: bool = True,
+) -> str:
+    module = directory / "sample_distribution_plugin.py"
+
+    body = """
+from wilfred import (
+    PluginDefinition,
+    ToolDefinition,
+    ToolPermission,
+)
+
+
+def factory(environ):
+    expected = environ["PLUGIN_TEST_VALUE"]
+
+    def register(registry):
+        registry.register(
+            ToolDefinition(
+                name="sample_configured_tool",
+                description="Configured test tool.",
+                handler=lambda: {"value": expected},
+                permission=ToolPermission.READ,
+            )
+        )
+
+    return PluginDefinition(
+        name="sample-configured",
+        register=register,
+    )
+"""
+
+    if not return_plugin:
+        body = """
+def factory(environ):
+    return object()
+"""
+
+    module.write_text(
+        body.strip() + "\n",
+        encoding="utf-8",
+    )
+
+    return "sample_distribution_plugin:factory"
+
+
+def test_discover_configured_plugin_factory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = write_factory(tmp_path)
+
+    monkeypatch.syspath_prepend(
+        str(tmp_path)
+    )
+
+    plugins = discover_configured_plugins(
+        [spec],
+        environ={
+            "PLUGIN_TEST_VALUE": "ready",
+        },
+    )
+
+    assert [
+        plugin.name
+        for plugin in plugins
+    ] == [
+        "sample-configured",
+    ]
+
+
+def test_configured_plugin_spec_requires_factory() -> None:
+    with pytest.raises(
+        ValueError,
+        match="module:factory",
+    ):
+        discover_configured_plugins(
+            ["invalid"],
+            environ={},
+        )
+
+
+def test_configured_factory_must_return_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spec = write_factory(
+        tmp_path,
+        return_plugin=False,
+    )
+
+    monkeypatch.syspath_prepend(
+        str(tmp_path)
+    )
+
+    sys.modules.pop(
+        "sample_distribution_plugin",
+        None,
+    )
+
+    with pytest.raises(
+        TypeError,
+        match="PluginDefinition",
+    ):
+        discover_configured_plugins(
+            [spec],
+            environ={},
+        )


### PR DESCRIPTION
Adds the provider-neutral runtime bootstrap required by the official standalone distribution. Installed integrations remain external packages and still register through the normal Wilfred plugin contract.