### PR TITLE
Restore public status contract [WILF-042]

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ stable releases:
 - native Butler capabilities;
 - the Wilfred `0.2.0` Public Alpha.
 
-The crowdfunding campaign will only launch after the real `0.2.0` release
+The crowdfunding campaign will only launch after the `0.2.0` release
 exists and completes its release verification.
 
 ## Public boundary


### PR DESCRIPTION
Corrects the public crowdfunding status wording so the established documentation contract remains valid. No release or fundraising state changes.