### PR TITLE
release: Wilfred 0.2.0 Public Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.2.0.dev0"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.2.0"}
 ```
 
 The same runtime can also be started with:
@@ -102,7 +102,7 @@ Wilfred currently provides:
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification as a standalone distribution.
 
-The `0.2.0.dev0` development line also includes:
+The `0.2.0` Public Alpha also includes:
 
 - the official public Home Assistant plugin;
 - the reference Docker distribution.

--- a/distribution/bom.toml
+++ b/distribution/bom.toml
@@ -8,7 +8,7 @@ version = "0.1.3"
 
 [components.wilfred]
 package = "wilfred-butler"
-version = "0.2.0.dev0"
+version = "0.2.0"
 
 [components.home_assistant]
 package = "wilfred-home-assistant"

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,7 +33,7 @@ public distribution works without another butler repository.
 Wilfred uses the `0.1.x` series for small, verifiable milestones on the path
 to `0.2.0`.
 
-The current development baseline is `0.2.0.dev0`.
+The current release baseline is `0.2.0`.
 
 Subsequent `0.1.x` versions represent concrete increments in packaging,
 distribution, onboarding and public usability. They are milestones, not a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -71,7 +71,7 @@ wilfred
 Expected output:
 
 ```json
-{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.2.0.dev0"}
+{"locale": "en", "log_level": "INFO", "name": "Wilfred", "runtime": "standalone-bootstrap", "status": "ok", "version": "0.2.0"}
 ```
 
 The module entrypoint is equivalent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.2.0.dev0"
+version = "0.2.0"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -45,7 +45,7 @@ def test_reference_binding_is_loopback_only() -> None:
     )
 
 
-def test_distribution_bom_matches_dev_line() -> None:
+def test_distribution_bom_matches_release_baseline() -> None:
     with (
         ROOT / "distribution" / "bom.toml"
     ).open("rb") as stream:
@@ -58,7 +58,7 @@ def test_distribution_bom_matches_dev_line() -> None:
     )
     assert (
         bom["components"]["wilfred"]["version"]
-        == "0.2.0.dev0"
+        == "0.2.0"
     )
     assert (
         bom["components"]["home_assistant"]["version"]


### PR DESCRIPTION
Prepare the Wilfred 0.2.0 Public Alpha release.

- bump Wilfred to 0.2.0
- align distribution BOM
- update release documentation/examples
- retain Butler Core 0.1.3 baseline
- full test suite passed
- clean package build and clean-room install verified