### PR TITLE
docs(release): Wilfred 0.2.0 release notes

### DIFF
--- a/docs/releases/0.2.0.md
+++ b/docs/releases/0.2.0.md
@@ -1,0 +1,43 @@
+# Wilfred 0.2.0
+
+Wilfred 0.2.0 is the first Public Alpha release.
+
+This release establishes the public Butler runtime as a standalone,
+provider-neutral layer for safe and extensible automation orchestration.
+
+## Highlights
+
+- Butler Core 0.1.3 as the execution and contract foundation.
+- Public HTTP API for runtime, tools and goals.
+- Verified workflows with READ -> ACTION -> READ -> VERIFY semantics.
+- Persistent workflow results.
+- Official Home Assistant plugin integration.
+- Official Docker distribution and container verification.
+- Standalone installation and onboarding documentation.
+- Public/private development boundary documented and enforced.
+
+## Architecture
+
+Wilfred sits between clients and registered tools or plugins:
+
+Client -> Wilfred -> Registered Tool / Plugin -> Service
+
+Home Assistant remains responsible for physical orchestration,
+integrations and device ownership.
+
+The private Keriol Home deployment continues to act as a real-world
+proving ground. Reusable capabilities are generalized into Wilfred,
+Butler Core or official plugins only after they have suitable public
+contracts, tests and documentation.
+
+## Public Alpha
+
+0.2.0 is a Public Alpha.
+
+The runtime, APIs and plugin contracts may continue to evolve as the
+project receives real-world feedback. Compatibility guarantees remain
+more limited than they will be for a stable release.
+
+The next development cycle will focus on hardening and progressively
+porting additional reusable capabilities already validated in the
+private proving ground.


### PR DESCRIPTION
Add the release notes required by the Wilfred Release workflow for the 0.2.0 Public Alpha.