### PR TITLE
WILF-048: add test coverage reporting

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -41,9 +41,17 @@ jobs:
         run: |
           python -m compileall -q src tests
 
-      - name: Run test suite
+      - name: Run test suite with coverage
         run: |
-          pytest -q
+          pytest -q --cov=wilfred --cov-report=term-missing --cov-report=xml:coverage.xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: wilfred-coverage-${{ github.sha }}
+          path: coverage.xml
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Build package
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "httpx2>=2,<3",
     "pydantic>=2.9,<3",
     "pytest>=9,<10",
+    "pytest-cov>=7,<8",
     "setuptools>=68",
     "uvicorn>=0.34,<1",
     "wheel>=0.45",

--- a/tests/test_development_environment.py
+++ b/tests/test_development_environment.py
@@ -52,6 +52,7 @@ class DevelopmentEnvironmentTests(unittest.TestCase):
                 "httpx2",
                 "pydantic",
                 "pytest",
+                "pytest-cov",
                 "setuptools",
                 "uvicorn",
                 "wheel",


### PR DESCRIPTION
## Summary

Adds the initial Wilfred test coverage baseline to public CI without introducing a fail-under threshold.

## Changes

- adds `pytest-cov` to the `dev` optional dependencies;
- runs the full suite with coverage for the `wilfred` package;
- prints a terminal coverage report in GitHub Actions;
- generates `coverage.xml`;
- uploads `coverage.xml` as a CI artifact;
- keeps build and clean-room wheel validation in the existing workflow.

## Validation

GitHub Actions is the authoritative validation environment for this office-side workflow. The PR should prove tests, build, clean-room install and coverage artifact generation together.

Closes #44.