### PR TITLE
WILF-053: define capability and domain contracts

### DIFF
--- a/docs/capability-domain-contracts.md
+++ b/docs/capability-domain-contracts.md
@@ -1,0 +1,64 @@
+# Capability and domain contracts
+
+Wilfred models semantic ownership explicitly through two provider-neutral public contracts:
+
+- `DomainDefinition` identifies a domain that owns related knowledge and behaviour;
+- `CapabilityDefinition` identifies something the Butler knows how to do inside one domain.
+
+These contracts describe semantic ownership. They do not connect to external services, execute operations or replace the tool registry.
+
+## DomainDefinition
+
+```python
+from wilfred import DomainDefinition
+
+media = DomainDefinition(
+    name="media",
+    description="Media discovery and playback.",
+)
+
+assert media.identity == "media"
+```
+
+A domain name is its stable public identity. Names use the same repository-safe form as plugin identities: lowercase alphanumeric segments separated by `.`, `_` or `-`.
+
+## CapabilityDefinition
+
+```python
+from wilfred import CapabilityDefinition
+
+playback = CapabilityDefinition(
+    name="playback",
+    domain="media",
+    description="Play resolved media.",
+)
+
+assert playback.identity == "media.playback"
+```
+
+Capability identity is deterministic and domain-qualified. This prevents the same short capability name in two domains from being treated as the same semantic owner.
+
+Both definitions are immutable value objects. Equivalent definitions compare equally and can be used wherever deterministic public metadata is required.
+
+## Ownership boundary
+
+The contracts intentionally do not introduce another registry into Butler Core or Wilfred.
+
+The current separation remains:
+
+- integration/provider: connection to an external service;
+- plugin: packaging and integration boundary;
+- domain: owner of related knowledge and behaviour;
+- capability: something the Butler knows how to do;
+- tool: typed executable operation;
+- goal: requested outcome.
+
+Butler Core remains provider-neutral and continues to own generic execution and resolution foundations. Wilfred owns the semantic capability/domain model.
+
+## Compatibility and next step
+
+Existing tool-only plugins and existing `WilfredRuntime` construction are unchanged by these contracts. A consumer does not need to declare domains or capabilities merely to continue using the current public plugin/tool APIs.
+
+Plugin declaration, loading, duplicate-identity validation and runtime capability discovery are deliberately separate follow-up work. They must build on these contracts rather than duplicating them.
+
+This separation keeps the first public contract small and avoids making speculative registry or loader behaviour part of the compatibility surface before it is needed.

--- a/src/wilfred/__init__.py
+++ b/src/wilfred/__init__.py
@@ -5,6 +5,10 @@ from importlib.metadata import (
     version as package_version,
 )
 
+from wilfred.capabilities import (
+    CapabilityDefinition,
+    DomainDefinition,
+)
 from wilfred.config import (
     ButlerIdentity,
     ConfigurationError,
@@ -64,7 +68,9 @@ from wilfred.runtime import WilfredRuntime
 
 __all__ = [
     "ButlerIdentity",
+    "CapabilityDefinition",
     "ConfigurationError",
+    "DomainDefinition",
     "ExecutionEngine",
     "ExecutionPolicy",
     "ExecutionRequest",

--- a/src/wilfred/capabilities.py
+++ b/src/wilfred/capabilities.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+
+_PUBLIC_NAME_PATTERN = re.compile(
+    r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*"
+)
+
+
+def _validate_public_name(kind: str, value: str) -> None:
+    if _PUBLIC_NAME_PATTERN.fullmatch(value) is None:
+        raise ValueError(
+            f"Invalid {kind} name: {value!r}"
+        )
+
+
+@dataclass(frozen=True)
+class DomainDefinition:
+    """Provider-neutral public identity for one Wilfred behavior domain."""
+
+    name: str
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_public_name("domain", self.name)
+
+    @property
+    def identity(self) -> str:
+        """Return the stable public domain identity."""
+
+        return self.name
+
+
+@dataclass(frozen=True)
+class CapabilityDefinition:
+    """Provider-neutral public identity for something Wilfred can do."""
+
+    name: str
+    domain: str
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        _validate_public_name("capability", self.name)
+        _validate_public_name("domain", self.domain)
+
+    @property
+    def identity(self) -> str:
+        """Return the stable domain-qualified capability identity."""
+
+        return f"{self.domain}.{self.name}"
+
+
+__all__ = [
+    "CapabilityDefinition",
+    "DomainDefinition",
+]

--- a/tests/test_capability_contracts.py
+++ b/tests/test_capability_contracts.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import unittest
+
+from wilfred import (
+    CapabilityDefinition,
+    DomainDefinition,
+)
+
+
+class CapabilityContractTests(unittest.TestCase):
+    def test_domain_has_stable_public_identity(self) -> None:
+        domain = DomainDefinition(
+            name="media",
+            description="Media discovery and playback.",
+        )
+
+        self.assertEqual(domain.identity, "media")
+        self.assertEqual(domain.name, "media")
+        self.assertEqual(
+            domain.description,
+            "Media discovery and playback.",
+        )
+
+    def test_capability_identity_is_domain_qualified(self) -> None:
+        capability = CapabilityDefinition(
+            name="playback",
+            domain="media",
+            description="Play resolved media.",
+        )
+
+        self.assertEqual(capability.identity, "media.playback")
+        self.assertEqual(capability.domain, "media")
+
+    def test_contracts_are_immutable(self) -> None:
+        domain = DomainDefinition(name="media")
+        capability = CapabilityDefinition(
+            name="playback",
+            domain="media",
+        )
+
+        with self.assertRaises(AttributeError):
+            domain.name = "other"  # type: ignore[misc]
+
+        with self.assertRaises(AttributeError):
+            capability.name = "other"  # type: ignore[misc]
+
+    def test_invalid_domain_name_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid domain name",
+        ):
+            DomainDefinition(name="Media Domain")
+
+    def test_invalid_capability_name_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid capability name",
+        ):
+            CapabilityDefinition(
+                name="Play Media",
+                domain="media",
+            )
+
+    def test_invalid_capability_domain_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "Invalid domain name",
+        ):
+            CapabilityDefinition(
+                name="playback",
+                domain="Media Domain",
+            )
+
+    def test_equivalent_definitions_compare_deterministically(self) -> None:
+        left = CapabilityDefinition(
+            name="playback",
+            domain="media",
+            description="Play resolved media.",
+        )
+        right = CapabilityDefinition(
+            name="playback",
+            domain="media",
+            description="Play resolved media.",
+        )
+
+        self.assertEqual(left, right)
+        self.assertEqual(hash(left), hash(right))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add provider-neutral `DomainDefinition` and `CapabilityDefinition` public contracts;
- give domains stable identities and capabilities deterministic domain-qualified identities;
- keep the contracts immutable and independent from plugin loading, registries and Butler Core;
- export both contracts from the public `wilfred` package surface;
- add focused contract tests and public documentation;
- preserve compatibility for existing tool-only plugins and current `WilfredRuntime` construction.

## Boundary

This PR intentionally does **not** change plugin declarations, plugin loading, resolver composition or runtime capability discovery. Those remain follow-up work under WILF-054 and later issues.

Closes #35.