### PR TITLE
WILF-054: let plugins declare capabilities and domains

### DIFF
--- a/docs/capability-domain-contracts.md
+++ b/docs/capability-domain-contracts.md
@@ -40,6 +40,47 @@ Capability identity is deterministic and domain-qualified. This prevents the sam
 
 Both definitions are immutable value objects. Equivalent definitions compare equally and can be used wherever deterministic public metadata is required.
 
+## Plugin declarations
+
+A public plugin may declare the domains and capabilities it owns alongside its existing tool registrar:
+
+```python
+from wilfred import CapabilityDefinition, DomainDefinition
+from wilfred.plugins import PluginDefinition
+
+plugin = PluginDefinition(
+    name="example.media",
+    register=register_tools,
+    domains=(
+        DomainDefinition(
+            name="media",
+            description="Media discovery and playback.",
+        ),
+    ),
+    capabilities=(
+        CapabilityDefinition(
+            name="playback",
+            domain="media",
+            description="Play resolved media.",
+        ),
+    ),
+)
+```
+
+Declarations are normalized into deterministic identity order. A capability must reference a domain declared by the same plugin, making semantic ownership explicit rather than inferred from tool names or conversation code.
+
+When multiple plugins are loaded together, Wilfred validates semantic ownership before mutating the shared tool registry. Duplicate domain identities are rejected clearly rather than allowing two plugins to become competing owners.
+
+`PluginLoadResult` reports the deterministic `domain_names` and `capability_names` contributed by each loaded plugin in addition to its registered `tool_names`.
+
+## Compatibility
+
+Existing tool-only plugins remain valid. `domains` and `capabilities` default to empty tuples, so current plugin factories and current `WilfredRuntime` construction do not need to change merely to keep working.
+
+A plugin that declares capabilities opts into the semantic ownership contract. It must also declare the corresponding domains it owns.
+
+Runtime-wide capability discovery and capability-owned deterministic resolver composition are separate follow-up layers. They should consume these declarations rather than create parallel semantic registries.
+
 ## Ownership boundary
 
 The contracts intentionally do not introduce another registry into Butler Core or Wilfred.
@@ -53,12 +94,4 @@ The current separation remains:
 - tool: typed executable operation;
 - goal: requested outcome.
 
-Butler Core remains provider-neutral and continues to own generic execution and resolution foundations. Wilfred owns the semantic capability/domain model.
-
-## Compatibility and next step
-
-Existing tool-only plugins and existing `WilfredRuntime` construction are unchanged by these contracts. A consumer does not need to declare domains or capabilities merely to continue using the current public plugin/tool APIs.
-
-Plugin declaration, loading, duplicate-identity validation and runtime capability discovery are deliberately separate follow-up work. They must build on these contracts rather than duplicating them.
-
-This separation keeps the first public contract small and avoids making speculative registry or loader behaviour part of the compatibility surface before it is needed.
+Butler Core remains provider-neutral and continues to own generic execution and resolution foundations. Wilfred owns the semantic capability/domain model and plugin-level declaration rules.

--- a/src/wilfred/plugins/contracts.py
+++ b/src/wilfred/plugins/contracts.py
@@ -4,6 +4,11 @@ from dataclasses import dataclass
 import re
 from typing import TYPE_CHECKING, Callable
 
+from wilfred.capabilities import (
+    CapabilityDefinition,
+    DomainDefinition,
+)
+
 
 if TYPE_CHECKING:
     from wilfred.registry import ToolRegistry
@@ -22,6 +27,8 @@ class PluginDefinition:
     register: PluginRegistrar
     description: str = ""
     version: str = "0.1.0"
+    domains: tuple[DomainDefinition, ...] = ()
+    capabilities: tuple[CapabilityDefinition, ...] = ()
 
     def __post_init__(self) -> None:
         if _PLUGIN_NAME_PATTERN.fullmatch(self.name) is None:
@@ -40,8 +47,84 @@ class PluginDefinition:
                 "Plugin register must be callable."
             )
 
+        domains = tuple(self.domains)
+        capabilities = tuple(self.capabilities)
+
+        if not all(
+            isinstance(domain, DomainDefinition)
+            for domain in domains
+        ):
+            raise TypeError(
+                "Plugin domains must contain DomainDefinition values."
+            )
+
+        if not all(
+            isinstance(capability, CapabilityDefinition)
+            for capability in capabilities
+        ):
+            raise TypeError(
+                "Plugin capabilities must contain CapabilityDefinition values."
+            )
+
+        domain_names = [domain.identity for domain in domains]
+        duplicate_domains = sorted(
+            name
+            for name in set(domain_names)
+            if domain_names.count(name) > 1
+        )
+
+        if duplicate_domains:
+            raise ValueError(
+                f"Plugin {self.name!r} declares duplicate domains: "
+                f"{', '.join(duplicate_domains)}"
+            )
+
+        capability_names = [
+            capability.identity
+            for capability in capabilities
+        ]
+        duplicate_capabilities = sorted(
+            name
+            for name in set(capability_names)
+            if capability_names.count(name) > 1
+        )
+
+        if duplicate_capabilities:
+            raise ValueError(
+                f"Plugin {self.name!r} declares duplicate capabilities: "
+                f"{', '.join(duplicate_capabilities)}"
+            )
+
+        owned_domains = set(domain_names)
+
+        for capability in capabilities:
+            if capability.domain not in owned_domains:
+                raise ValueError(
+                    f"Plugin {self.name!r} capability "
+                    f"{capability.identity!r} references undeclared domain "
+                    f"{capability.domain!r}."
+                )
+
+        object.__setattr__(
+            self,
+            "domains",
+            tuple(sorted(domains, key=lambda domain: domain.identity)),
+        )
+        object.__setattr__(
+            self,
+            "capabilities",
+            tuple(
+                sorted(
+                    capabilities,
+                    key=lambda capability: capability.identity,
+                )
+            ),
+        )
+
 
 @dataclass(frozen=True)
 class PluginLoadResult:
     plugin_name: str
     tool_names: tuple[str, ...]
+    domain_names: tuple[str, ...] = ()
+    capability_names: tuple[str, ...] = ()

--- a/src/wilfred/plugins/loader.py
+++ b/src/wilfred/plugins/loader.py
@@ -52,7 +52,6 @@ def discover_plugins(
     )
 
 
-
 def _configured_plugin_from_spec(
     spec: str,
     *,
@@ -143,6 +142,35 @@ def discover_configured_plugins(
     )
 
 
+def _validate_semantic_ownership(
+    plugins: Iterable[PluginDefinition],
+) -> None:
+    domain_owners: dict[str, str] = {}
+    capability_owners: dict[str, str] = {}
+
+    for plugin in plugins:
+        for domain in plugin.domains:
+            previous = domain_owners.get(domain.identity)
+
+            if previous is not None:
+                raise ValueError(
+                    f"Duplicate domain identity {domain.identity!r} "
+                    f"declared by plugins {previous!r} and {plugin.name!r}."
+                )
+
+            domain_owners[domain.identity] = plugin.name
+
+        for capability in plugin.capabilities:
+            previous = capability_owners.get(capability.identity)
+
+            if previous is not None:
+                raise ValueError(
+                    f"Duplicate capability identity {capability.identity!r} "
+                    f"declared by plugins {previous!r} and {plugin.name!r}."
+                )
+
+            capability_owners[capability.identity] = plugin.name
+
 
 def load_plugin(
     registry: ToolRegistry,
@@ -177,6 +205,14 @@ def load_plugin(
     return PluginLoadResult(
         plugin_name=plugin.name,
         tool_names=tool_names,
+        domain_names=tuple(
+            domain.identity
+            for domain in plugin.domains
+        ),
+        capability_names=tuple(
+            capability.identity
+            for capability in plugin.capabilities
+        ),
     )
 
 
@@ -201,6 +237,8 @@ def load_plugins(
             "Duplicate plugin names: "
             f"{', '.join(duplicates)}"
         )
+
+    _validate_semantic_ownership(ordered)
 
     return tuple(
         load_plugin(registry, plugin)

--- a/tests/test_plugin_capabilities.py
+++ b/tests/test_plugin_capabilities.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import unittest
+
+from wilfred import (
+    CapabilityDefinition,
+    DomainDefinition,
+    ToolDefinition,
+    ToolRegistry,
+)
+from wilfred.plugins import (
+    PluginDefinition,
+    load_plugins,
+)
+
+
+def _register_tool(name: str):
+    def register(registry: ToolRegistry) -> None:
+        registry.register(
+            ToolDefinition(
+                name=name,
+                description=f"Test tool {name}.",
+                handler=lambda: name,
+            )
+        )
+
+    return register
+
+
+class PluginCapabilityTests(unittest.TestCase):
+    def test_tool_only_plugin_remains_compatible(self) -> None:
+        plugin = PluginDefinition(
+            name="demo.tool-only",
+            register=_register_tool("demo_tool_only"),
+        )
+
+        results = load_plugins(
+            ToolRegistry(),
+            [plugin],
+        )
+
+        self.assertEqual(results[0].domain_names, ())
+        self.assertEqual(results[0].capability_names, ())
+
+    def test_plugin_declares_domains_and_capabilities_deterministically(self) -> None:
+        plugin = PluginDefinition(
+            name="demo.media",
+            register=_register_tool("demo_media"),
+            domains=(
+                DomainDefinition(name="system"),
+                DomainDefinition(name="media"),
+            ),
+            capabilities=(
+                CapabilityDefinition(
+                    name="search",
+                    domain="media",
+                ),
+                CapabilityDefinition(
+                    name="status",
+                    domain="system",
+                ),
+                CapabilityDefinition(
+                    name="playback",
+                    domain="media",
+                ),
+            ),
+        )
+
+        self.assertEqual(
+            tuple(domain.identity for domain in plugin.domains),
+            ("media", "system"),
+        )
+        self.assertEqual(
+            tuple(
+                capability.identity
+                for capability in plugin.capabilities
+            ),
+            (
+                "media.playback",
+                "media.search",
+                "system.status",
+            ),
+        )
+
+        results = load_plugins(
+            ToolRegistry(),
+            [plugin],
+        )
+
+        self.assertEqual(
+            results[0].domain_names,
+            ("media", "system"),
+        )
+        self.assertEqual(
+            results[0].capability_names,
+            (
+                "media.playback",
+                "media.search",
+                "system.status",
+            ),
+        )
+
+    def test_capability_must_belong_to_plugin_owned_domain(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "references undeclared domain 'media'",
+        ):
+            PluginDefinition(
+                name="demo.invalid",
+                register=_register_tool("demo_invalid"),
+                capabilities=(
+                    CapabilityDefinition(
+                        name="playback",
+                        domain="media",
+                    ),
+                ),
+            )
+
+    def test_duplicate_domain_ownership_is_rejected_before_tool_loading(self) -> None:
+        registry = ToolRegistry()
+        first = PluginDefinition(
+            name="demo.first",
+            register=_register_tool("demo_first"),
+            domains=(DomainDefinition(name="media"),),
+        )
+        second = PluginDefinition(
+            name="demo.second",
+            register=_register_tool("demo_second"),
+            domains=(DomainDefinition(name="media"),),
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Duplicate domain identity 'media'",
+        ):
+            load_plugins(
+                registry,
+                [second, first],
+            )
+
+        self.assertEqual(registry.names(), [])
+
+    def test_duplicate_declarations_inside_plugin_are_rejected(self) -> None:
+        domain = DomainDefinition(name="media")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "declares duplicate domains: media",
+        ):
+            PluginDefinition(
+                name="demo.duplicate",
+                register=_register_tool("demo_duplicate"),
+                domains=(domain, domain),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- extend `PluginDefinition` with optional deterministic domain and capability declarations;
- require declared capabilities to belong to domains owned by the same plugin;
- reject duplicate semantic ownership before mutating the shared tool registry;
- expose loaded `domain_names` and `capability_names` in `PluginLoadResult`;
- preserve existing tool-only plugin compatibility through empty declaration defaults;
- add focused ownership/compatibility tests and update public documentation.

## Boundary

This PR does not add runtime-wide capability discovery, capability-owned resolver composition, or another Butler Core registry. Those remain separate follow-up work.

Closes #36.