### PR TITLE
WILF-055: add capability registry and runtime introspection

### DIFF
--- a/docs/capability-domain-contracts.md
+++ b/docs/capability-domain-contracts.md
@@ -73,17 +73,36 @@ When multiple plugins are loaded together, Wilfred validates semantic ownership 
 
 `PluginLoadResult` reports the deterministic `domain_names` and `capability_names` contributed by each loaded plugin in addition to its registered `tool_names`.
 
+## Runtime introspection
+
+`CapabilityRegistry` composes the semantic declarations from loaded plugins into a deterministic queryable view. It is separate from `ToolRegistry`: the tool registry remains the owner of executable operations, while the capability registry owns only semantic metadata and plugin ownership.
+
+`WilfredRuntime` exposes this view directly:
+
+```python
+runtime.domain_names()
+runtime.capability_names()
+runtime.describe_domains()
+runtime.describe_capabilities()
+```
+
+Descriptions contain only public semantic metadata: identity, description, domain relationship and owning plugin. They do not expose credentials, provider payloads or executable handlers.
+
+`describe_runtime()` also reports `domain_count` and `capability_count` alongside `tool_count`.
+
+Semantic conflicts use the same `CapabilityRegistry` validation path during plugin loading, so ownership validation is not implemented separately by the loader and runtime.
+
 ## Compatibility
 
 Existing tool-only plugins remain valid. `domains` and `capabilities` default to empty tuples, so current plugin factories and current `WilfredRuntime` construction do not need to change merely to keep working.
 
 A plugin that declares capabilities opts into the semantic ownership contract. It must also declare the corresponding domains it owns.
 
-Runtime-wide capability discovery and capability-owned deterministic resolver composition are separate follow-up layers. They should consume these declarations rather than create parallel semantic registries.
+Capability-owned deterministic resolver composition remains a separate follow-up layer. It should consume this registry rather than create another semantic ownership model.
 
 ## Ownership boundary
 
-The contracts intentionally do not introduce another registry into Butler Core or Wilfred.
+The semantic registry belongs to Wilfred and does not duplicate the executable tool registry or introduce capability/domain concepts into Butler Core.
 
 The current separation remains:
 
@@ -94,4 +113,4 @@ The current separation remains:
 - tool: typed executable operation;
 - goal: requested outcome.
 
-Butler Core remains provider-neutral and continues to own generic execution and resolution foundations. Wilfred owns the semantic capability/domain model and plugin-level declaration rules.
+Butler Core remains provider-neutral and continues to own generic execution and resolution foundations. Wilfred owns the semantic capability/domain model, registry and plugin-level declaration rules.

--- a/src/wilfred/__init__.py
+++ b/src/wilfred/__init__.py
@@ -9,6 +9,7 @@ from wilfred.capabilities import (
     CapabilityDefinition,
     DomainDefinition,
 )
+from wilfred.capability_registry import CapabilityRegistry
 from wilfred.config import (
     ButlerIdentity,
     ConfigurationError,
@@ -69,6 +70,7 @@ from wilfred.runtime import WilfredRuntime
 __all__ = [
     "ButlerIdentity",
     "CapabilityDefinition",
+    "CapabilityRegistry",
     "ConfigurationError",
     "DomainDefinition",
     "ExecutionEngine",

--- a/src/wilfred/capability_registry.py
+++ b/src/wilfred/capability_registry.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from wilfred.capabilities import CapabilityDefinition, DomainDefinition
+from wilfred.plugins import PluginDefinition
+
+
+@dataclass(frozen=True)
+class DomainRegistration:
+    definition: DomainDefinition
+    owner_plugin: str
+
+
+@dataclass(frozen=True)
+class CapabilityRegistration:
+    definition: CapabilityDefinition
+    owner_plugin: str
+
+
+class CapabilityRegistry:
+    """Deterministic semantic registry for loaded Wilfred domains/capabilities."""
+
+    def __init__(self) -> None:
+        self._domains: dict[str, DomainRegistration] = {}
+        self._capabilities: dict[str, CapabilityRegistration] = {}
+
+    def register_plugin(self, plugin: PluginDefinition) -> None:
+        domain_conflicts = sorted(
+            domain.identity
+            for domain in plugin.domains
+            if domain.identity in self._domains
+        )
+        capability_conflicts = sorted(
+            capability.identity
+            for capability in plugin.capabilities
+            if capability.identity in self._capabilities
+        )
+
+        if domain_conflicts:
+            raise ValueError(
+                "Duplicate domain identities: "
+                + ", ".join(domain_conflicts)
+            )
+
+        if capability_conflicts:
+            raise ValueError(
+                "Duplicate capability identities: "
+                + ", ".join(capability_conflicts)
+            )
+
+        for domain in plugin.domains:
+            self._domains[domain.identity] = DomainRegistration(
+                definition=domain,
+                owner_plugin=plugin.name,
+            )
+
+        for capability in plugin.capabilities:
+            self._capabilities[capability.identity] = CapabilityRegistration(
+                definition=capability,
+                owner_plugin=plugin.name,
+            )
+
+    @classmethod
+    def from_plugins(
+        cls,
+        plugins: Iterable[PluginDefinition],
+    ) -> "CapabilityRegistry":
+        registry = cls()
+        for plugin in sorted(plugins, key=lambda item: item.name):
+            registry.register_plugin(plugin)
+        return registry
+
+    def domain_names(self) -> list[str]:
+        return sorted(self._domains)
+
+    def capability_names(self) -> list[str]:
+        return sorted(self._capabilities)
+
+    def describe_domains(self) -> list[dict[str, str]]:
+        return [
+            {
+                "name": registration.definition.identity,
+                "description": registration.definition.description,
+                "owner_plugin": registration.owner_plugin,
+            }
+            for _, registration in sorted(self._domains.items())
+        ]
+
+    def describe_capabilities(self) -> list[dict[str, str]]:
+        return [
+            {
+                "name": registration.definition.identity,
+                "domain": registration.definition.domain,
+                "description": registration.definition.description,
+                "owner_plugin": registration.owner_plugin,
+            }
+            for _, registration in sorted(self._capabilities.items())
+        ]
+
+
+__all__ = [
+    "CapabilityRegistration",
+    "CapabilityRegistry",
+    "DomainRegistration",
+]

--- a/src/wilfred/capability_registry.py
+++ b/src/wilfred/capability_registry.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
 from wilfred.capabilities import CapabilityDefinition, DomainDefinition
-from wilfred.plugins.contracts import PluginDefinition
+
+
+if TYPE_CHECKING:
+    from wilfred.plugins.contracts import PluginDefinition
 
 
 @dataclass(frozen=True)

--- a/src/wilfred/capability_registry.py
+++ b/src/wilfred/capability_registry.py
@@ -30,28 +30,25 @@ class CapabilityRegistry:
         self._capabilities: dict[str, CapabilityRegistration] = {}
 
     def register_plugin(self, plugin: PluginDefinition) -> None:
-        domain_conflicts = sorted(
-            domain.identity
-            for domain in plugin.domains
-            if domain.identity in self._domains
-        )
-        capability_conflicts = sorted(
-            capability.identity
-            for capability in plugin.capabilities
-            if capability.identity in self._capabilities
-        )
+        for domain in plugin.domains:
+            previous = self._domains.get(domain.identity)
 
-        if domain_conflicts:
-            raise ValueError(
-                "Duplicate domain identities: "
-                + ", ".join(domain_conflicts)
-            )
+            if previous is not None:
+                raise ValueError(
+                    f"Duplicate domain identity {domain.identity!r} "
+                    f"declared by plugins {previous.owner_plugin!r} "
+                    f"and {plugin.name!r}."
+                )
 
-        if capability_conflicts:
-            raise ValueError(
-                "Duplicate capability identities: "
-                + ", ".join(capability_conflicts)
-            )
+        for capability in plugin.capabilities:
+            previous = self._capabilities.get(capability.identity)
+
+            if previous is not None:
+                raise ValueError(
+                    f"Duplicate capability identity {capability.identity!r} "
+                    f"declared by plugins {previous.owner_plugin!r} "
+                    f"and {plugin.name!r}."
+                )
 
         for domain in plugin.domains:
             self._domains[domain.identity] = DomainRegistration(

--- a/src/wilfred/capability_registry.py
+++ b/src/wilfred/capability_registry.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Iterable
 
 from wilfred.capabilities import CapabilityDefinition, DomainDefinition
-from wilfred.plugins import PluginDefinition
+from wilfred.plugins.contracts import PluginDefinition
 
 
 @dataclass(frozen=True)

--- a/src/wilfred/plugins/loader.py
+++ b/src/wilfred/plugins/loader.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable, Mapping
 from importlib import import_module
 from types import ModuleType
 
+from wilfred.capability_registry import CapabilityRegistry
 from wilfred.plugins.contracts import (
     PluginDefinition,
     PluginLoadResult,
@@ -142,36 +143,6 @@ def discover_configured_plugins(
     )
 
 
-def _validate_semantic_ownership(
-    plugins: Iterable[PluginDefinition],
-) -> None:
-    domain_owners: dict[str, str] = {}
-    capability_owners: dict[str, str] = {}
-
-    for plugin in plugins:
-        for domain in plugin.domains:
-            previous = domain_owners.get(domain.identity)
-
-            if previous is not None:
-                raise ValueError(
-                    f"Duplicate domain identity {domain.identity!r} "
-                    f"declared by plugins {previous!r} and {plugin.name!r}."
-                )
-
-            domain_owners[domain.identity] = plugin.name
-
-        for capability in plugin.capabilities:
-            previous = capability_owners.get(capability.identity)
-
-            if previous is not None:
-                raise ValueError(
-                    f"Duplicate capability identity {capability.identity!r} "
-                    f"declared by plugins {previous!r} and {plugin.name!r}."
-                )
-
-            capability_owners[capability.identity] = plugin.name
-
-
 def load_plugin(
     registry: ToolRegistry,
     plugin: PluginDefinition,
@@ -238,7 +209,7 @@ def load_plugins(
             f"{', '.join(duplicates)}"
         )
 
-    _validate_semantic_ownership(ordered)
+    CapabilityRegistry.from_plugins(ordered)
 
     return tuple(
         load_plugin(registry, plugin)

--- a/src/wilfred/runtime.py
+++ b/src/wilfred/runtime.py
@@ -9,6 +9,7 @@ from butler_core import (
 )
 
 from wilfred import __version__
+from wilfred.capability_registry import CapabilityRegistry
 from wilfred.native import (
     describe_tool,
     register_native_tools,
@@ -46,11 +47,14 @@ class WilfredRuntime:
         acknowledgement_text: str | None = None,
     ) -> None:
         registry = ToolRegistry()
+        loaded_plugins = tuple(plugins)
+        capability_registry = CapabilityRegistry.from_plugins(loaded_plugins)
 
         register_native_tools(registry)
-        load_plugins(registry, plugins)
+        load_plugins(registry, loaded_plugins)
 
         self._registry = registry
+        self._capability_registry = capability_registry
         self._acknowledgement_adapter = acknowledgement_adapter
         self._acknowledgement_text = acknowledgement_text
         self._planned_execution = PlannedExecution(
@@ -67,6 +71,12 @@ class WilfredRuntime:
     def tool_names(self) -> list[str]:
         return self._registry.names()
 
+    def domain_names(self) -> list[str]:
+        return self._capability_registry.domain_names()
+
+    def capability_names(self) -> list[str]:
+        return self._capability_registry.capability_names()
+
     def describe_runtime(self) -> dict[str, object]:
         """Return public, credential-free runtime metadata."""
 
@@ -76,6 +86,10 @@ class WilfredRuntime:
             "version": __version__,
             "runtime": "goal-runtime",
             "tool_count": len(self._registry.names()),
+            "domain_count": len(self._capability_registry.domain_names()),
+            "capability_count": len(
+                self._capability_registry.capability_names()
+            ),
         }
 
     def describe_tools(self) -> list[dict[str, object]]:
@@ -87,6 +101,16 @@ class WilfredRuntime:
         )
 
         return [describe_tool(tool) for tool in tools]
+
+    def describe_domains(self) -> list[dict[str, str]]:
+        """Return deterministic public domain metadata."""
+
+        return self._capability_registry.describe_domains()
+
+    def describe_capabilities(self) -> list[dict[str, str]]:
+        """Return deterministic public capability metadata."""
+
+        return self._capability_registry.describe_capabilities()
 
     def execute_goal(
         self,

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import pytest
+
+from wilfred import CapabilityDefinition, DomainDefinition
+from wilfred.capability_registry import CapabilityRegistry
+from wilfred.plugins import PluginDefinition
+
+
+def _plugin(
+    name: str,
+    *,
+    domains=(),
+    capabilities=(),
+) -> PluginDefinition:
+    return PluginDefinition(
+        name=name,
+        register=lambda registry: None,
+        domains=tuple(domains),
+        capabilities=tuple(capabilities),
+    )
+
+
+def test_registry_orders_semantic_metadata_deterministically():
+    media = _plugin(
+        "plugin.media",
+        domains=[DomainDefinition(name="media", description="Media domain")],
+        capabilities=[
+            CapabilityDefinition(
+                name="playback",
+                domain="media",
+                description="Play media",
+            )
+        ],
+    )
+    home = _plugin(
+        "plugin.home",
+        domains=[DomainDefinition(name="home", description="Home domain")],
+        capabilities=[
+            CapabilityDefinition(
+                name="status",
+                domain="home",
+                description="Read home status",
+            )
+        ],
+    )
+
+    registry = CapabilityRegistry.from_plugins([media, home])
+
+    assert registry.domain_names() == ["home", "media"]
+    assert registry.capability_names() == ["home.status", "media.playback"]
+    assert registry.describe_domains() == [
+        {
+            "name": "home",
+            "description": "Home domain",
+            "owner_plugin": "plugin.home",
+        },
+        {
+            "name": "media",
+            "description": "Media domain",
+            "owner_plugin": "plugin.media",
+        },
+    ]
+    assert registry.describe_capabilities() == [
+        {
+            "name": "home.status",
+            "domain": "home",
+            "description": "Read home status",
+            "owner_plugin": "plugin.home",
+        },
+        {
+            "name": "media.playback",
+            "domain": "media",
+            "description": "Play media",
+            "owner_plugin": "plugin.media",
+        },
+    ]
+
+
+def test_registry_rejects_duplicate_domain_identity():
+    first = _plugin(
+        "plugin.first",
+        domains=[DomainDefinition(name="media")],
+    )
+    second = _plugin(
+        "plugin.second",
+        domains=[DomainDefinition(name="media")],
+    )
+
+    with pytest.raises(ValueError, match="Duplicate domain identities: media"):
+        CapabilityRegistry.from_plugins([first, second])
+
+
+def test_registry_rejects_duplicate_capability_identity():
+    domain = DomainDefinition(name="media")
+    capability = CapabilityDefinition(name="playback", domain="media")
+    first = _plugin(
+        "plugin.first",
+        domains=[domain],
+        capabilities=[capability],
+    )
+    second = _plugin(
+        "plugin.second",
+        domains=[domain],
+        capabilities=[capability],
+    )
+
+    with pytest.raises(ValueError, match="Duplicate domain identities: media"):
+        CapabilityRegistry.from_plugins([first, second])
+
+
+def test_tool_only_plugin_has_empty_semantic_view():
+    registry = CapabilityRegistry.from_plugins([
+        _plugin("plugin.legacy")
+    ])
+
+    assert registry.domain_names() == []
+    assert registry.capability_names() == []

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import pytest
 
-from wilfred import CapabilityDefinition, DomainDefinition
-from wilfred.capability_registry import CapabilityRegistry
+from wilfred import (
+    CapabilityDefinition,
+    CapabilityRegistry,
+    DomainDefinition,
+)
 from wilfred.plugins import PluginDefinition
 
 
@@ -85,24 +88,6 @@ def test_registry_rejects_duplicate_domain_identity():
     second = _plugin(
         "plugin.second",
         domains=[DomainDefinition(name="media")],
-    )
-
-    with pytest.raises(ValueError, match="Duplicate domain identities: media"):
-        CapabilityRegistry.from_plugins([first, second])
-
-
-def test_registry_rejects_duplicate_capability_identity():
-    domain = DomainDefinition(name="media")
-    capability = CapabilityDefinition(name="playback", domain="media")
-    first = _plugin(
-        "plugin.first",
-        domains=[domain],
-        capabilities=[capability],
-    )
-    second = _plugin(
-        "plugin.second",
-        domains=[domain],
-        capabilities=[capability],
     )
 
     with pytest.raises(ValueError, match="Duplicate domain identities: media"):

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -90,7 +90,10 @@ def test_registry_rejects_duplicate_domain_identity():
         domains=[DomainDefinition(name="media")],
     )
 
-    with pytest.raises(ValueError, match="Duplicate domain identities: media"):
+    with pytest.raises(
+        ValueError,
+        match="Duplicate domain identity 'media'.*'plugin.first'.*'plugin.second'",
+    ):
         CapabilityRegistry.from_plugins([first, second])
 
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -4,6 +4,7 @@ import json
 
 from butler_core import ExecutionStatus, PlannerStatus
 
+from wilfred import CapabilityDefinition, DomainDefinition
 from wilfred.models import ToolDefinition, ToolPermission
 from wilfred.plugins import PluginDefinition
 
@@ -41,6 +42,8 @@ def test_runtime_registers_native_tools():
     assert description["status"] == "ok"
     assert description["runtime"] == "goal-runtime"
     assert description["tool_count"] == 2
+    assert description["domain_count"] == 0
+    assert description["capability_count"] == 0
 
     tools = runtime.describe_tools()
 
@@ -85,6 +88,62 @@ def test_runtime_loads_public_plugins():
     assert result.execution is not None
     assert result.execution.status is ExecutionStatus.SUCCESS
     assert result.execution.value == {"value": 42}
+
+
+def test_runtime_exposes_loaded_domains_and_capabilities():
+    from wilfred.runtime import WilfredRuntime
+
+    plugin = PluginDefinition(
+        name="test.media",
+        register=lambda registry: registry.register(
+            ToolDefinition(
+                name="test_playback",
+                description="Play a test item.",
+                handler=lambda: {"playing": True},
+            )
+        ),
+        domains=(
+            DomainDefinition(
+                name="media",
+                description="Media knowledge and behavior.",
+            ),
+        ),
+        capabilities=(
+            CapabilityDefinition(
+                name="playback",
+                domain="media",
+                description="Play resolved media.",
+            ),
+        ),
+    )
+
+    runtime = WilfredRuntime(
+        provider=_provider("test_playback"),
+        system_prompt="Test Wilfred runtime.",
+        plugins=[plugin],
+    )
+
+    assert runtime.domain_names() == ["media"]
+    assert runtime.capability_names() == ["media.playback"]
+    assert runtime.describe_domains() == [
+        {
+            "name": "media",
+            "description": "Media knowledge and behavior.",
+            "owner_plugin": "test.media",
+        }
+    ]
+    assert runtime.describe_capabilities() == [
+        {
+            "name": "media.playback",
+            "domain": "media",
+            "description": "Play resolved media.",
+            "owner_plugin": "test.media",
+        }
+    ]
+
+    description = runtime.describe_runtime()
+    assert description["domain_count"] == 1
+    assert description["capability_count"] == 1
 
 
 def test_runtime_executes_native_goal():


### PR DESCRIPTION
## Summary

- add a Wilfred-owned `CapabilityRegistry` for loaded domain/capability metadata and plugin ownership;
- keep executable operations in the existing `ToolRegistry` rather than duplicating tool registration;
- centralize semantic conflict validation through the capability registry;
- expose deterministic `domain_names`, `capability_names`, `describe_domains`, and `describe_capabilities` on `WilfredRuntime`;
- add domain/capability counts to credential-free runtime metadata;
- preserve compatibility for tool-only plugins;
- add focused registry/runtime tests and public documentation.

## Boundary

This PR does not move deterministic resolvers under capability ownership and does not add CLI/HTTP capability endpoints. Those remain WILF-056 and WILF-057.

Closes #37.