### PR TITLE
WILF-056: capability-owned deterministic resolvers

### DIFF
--- a/docs/capability-domain-contracts.md
+++ b/docs/capability-domain-contracts.md
@@ -25,18 +25,27 @@ A domain name is its stable public identity. Names use the same repository-safe 
 ## CapabilityDefinition
 
 ```python
+from butler_core import ResolutionResult, ResolverDefinition
 from wilfred import CapabilityDefinition
 
 playback = CapabilityDefinition(
     name="playback",
     domain="media",
     description="Play resolved media.",
+    resolvers=(
+        ResolverDefinition(
+            name="media.playback.local",
+            handler=resolve_playback,
+        ),
+    ),
 )
 
 assert playback.identity == "media.playback"
 ```
 
 Capability identity is deterministic and domain-qualified. This prevents the same short capability name in two domains from being treated as the same semantic owner.
+
+A capability may own zero or more Butler Core `ResolverDefinition` values. Resolver declaration order is explicit and preserved inside the capability. Duplicate resolver names inside one capability are rejected.
 
 Both definitions are immutable value objects. Equivalent definitions compare equally and can be used wherever deterministic public metadata is required.
 
@@ -57,27 +66,23 @@ plugin = PluginDefinition(
             description="Media discovery and playback.",
         ),
     ),
-    capabilities=(
-        CapabilityDefinition(
-            name="playback",
-            domain="media",
-            description="Play resolved media.",
-        ),
-    ),
+    capabilities=(playback,),
 )
 ```
 
 Declarations are normalized into deterministic identity order. A capability must reference a domain declared by the same plugin, making semantic ownership explicit rather than inferred from tool names or conversation code.
 
-When multiple plugins are loaded together, Wilfred validates semantic ownership before mutating the shared tool registry. Duplicate domain identities are rejected clearly rather than allowing two plugins to become competing owners.
+When multiple plugins are loaded together, Wilfred validates semantic ownership before mutating the shared tool registry. Duplicate domain and capability identities are rejected clearly rather than allowing competing owners.
+
+Resolver names must also be unique across loaded capabilities. Butler Core reports the resolver name in resolution results and traces, so global uniqueness keeps that evidence attributable to one capability.
 
 `PluginLoadResult` reports the deterministic `domain_names` and `capability_names` contributed by each loaded plugin in addition to its registered `tool_names`.
 
 ## Runtime introspection
 
-`CapabilityRegistry` composes the semantic declarations from loaded plugins into a deterministic queryable view. It is separate from `ToolRegistry`: the tool registry remains the owner of executable operations, while the capability registry owns only semantic metadata and plugin ownership.
+`CapabilityRegistry` composes the semantic declarations from loaded plugins into a deterministic queryable view. It is separate from `ToolRegistry`: the tool registry remains the owner of executable operations, while the capability registry owns semantic metadata, plugin ownership and resolver composition.
 
-`WilfredRuntime` exposes this view directly:
+`WilfredRuntime` exposes the semantic view directly:
 
 ```python
 runtime.domain_names()
@@ -92,25 +97,41 @@ Descriptions contain only public semantic metadata: identity, description, domai
 
 Semantic conflicts use the same `CapabilityRegistry` validation path during plugin loading, so ownership validation is not implemented separately by the loader and runtime.
 
+## Deterministic resolver composition
+
+Capability-owned resolvers are composed automatically into the Butler Core `DeterministicResolutionPipeline` used by `WilfredRuntime`.
+
+Ordering is stable and explicit:
+
+1. resolver definitions supplied through the legacy `WilfredRuntime(resolvers=...)` parameter, preserving their existing order;
+2. capability-owned resolvers ordered by capability identity;
+3. within one capability, resolver declaration order is preserved.
+
+The legacy runtime parameter is a compatibility surface, not the preferred ownership model for new capability code. Existing consumers that use only `resolvers=...` retain their historical behavior while migrations can move resolvers into their owning capabilities incrementally.
+
+A capability resolver only resolves a goal into the normal planning result. It does not execute a tool directly. The resolved tool still passes through the same `ExecutionEngine`, `ExecutionPolicy`, permission validation and confirmation rules as planner-resolved goals. ACTION and DANGEROUS operations therefore cannot bypass policy merely because resolution was deterministic.
+
+If every deterministic resolver returns `NOT_HANDLED`, planner fallback remains unchanged.
+
 ## Compatibility
 
 Existing tool-only plugins remain valid. `domains` and `capabilities` default to empty tuples, so current plugin factories and current `WilfredRuntime` construction do not need to change merely to keep working.
 
 A plugin that declares capabilities opts into the semantic ownership contract. It must also declare the corresponding domains it owns.
 
-Capability-owned deterministic resolver composition remains a separate follow-up layer. It should consume this registry rather than create another semantic ownership model.
+Existing callers of `WilfredRuntime(resolvers=...)` remain supported. New domain behavior should prefer capability-owned resolvers so semantic ownership stays beside the capability that provides it.
 
 ## Ownership boundary
 
-The semantic registry belongs to Wilfred and does not duplicate the executable tool registry or introduce capability/domain concepts into Butler Core.
+The semantic registry belongs to Wilfred and does not duplicate the executable tool registry or introduce Wilfred capability/domain concepts into Butler Core.
 
 The current separation remains:
 
 - integration/provider: connection to an external service;
 - plugin: packaging and integration boundary;
 - domain: owner of related knowledge and behaviour;
-- capability: something the Butler knows how to do;
+- capability: something the Butler knows how to do and the deterministic resolvers it owns;
 - tool: typed executable operation;
 - goal: requested outcome.
 
-Butler Core remains provider-neutral and continues to own generic execution and resolution foundations. Wilfred owns the semantic capability/domain model, registry and plugin-level declaration rules.
+Butler Core remains provider-neutral and continues to own generic execution and resolution foundations. Wilfred owns the semantic capability/domain model, registry, plugin declaration rules and capability-to-resolver association.

--- a/src/wilfred/capabilities.py
+++ b/src/wilfred/capabilities.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 import re
 
+from butler_core import ResolverDefinition
+
 
 _PUBLIC_NAME_PATTERN = re.compile(
     r"[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*"
@@ -40,10 +42,36 @@ class CapabilityDefinition:
     name: str
     domain: str
     description: str = ""
+    resolvers: tuple[ResolverDefinition, ...] = ()
 
     def __post_init__(self) -> None:
         _validate_public_name("capability", self.name)
         _validate_public_name("domain", self.domain)
+
+        resolvers = tuple(self.resolvers)
+
+        if not all(
+            isinstance(resolver, ResolverDefinition)
+            for resolver in resolvers
+        ):
+            raise TypeError(
+                "Capability resolvers must contain ResolverDefinition values."
+            )
+
+        resolver_names = [resolver.name for resolver in resolvers]
+        duplicate_resolvers = sorted(
+            name
+            for name in set(resolver_names)
+            if resolver_names.count(name) > 1
+        )
+
+        if duplicate_resolvers:
+            raise ValueError(
+                f"Capability {self.identity!r} declares duplicate resolvers: "
+                f"{', '.join(duplicate_resolvers)}"
+            )
+
+        object.__setattr__(self, "resolvers", resolvers)
 
     @property
     def identity(self) -> str:

--- a/src/wilfred/capability_registry.py
+++ b/src/wilfred/capability_registry.py
@@ -43,6 +43,8 @@ class CapabilityRegistry:
                     f"and {plugin.name!r}."
                 )
 
+        pending_resolver_owners = dict(self._resolver_owners)
+
         for capability in plugin.capabilities:
             previous = self._capabilities.get(capability.identity)
 
@@ -54,7 +56,7 @@ class CapabilityRegistry:
                 )
 
             for resolver in capability.resolvers:
-                previous_capability = self._resolver_owners.get(resolver.name)
+                previous_capability = pending_resolver_owners.get(resolver.name)
 
                 if previous_capability is not None:
                     raise ValueError(
@@ -62,6 +64,8 @@ class CapabilityRegistry:
                         f"owned by capabilities {previous_capability!r} "
                         f"and {capability.identity!r}."
                     )
+
+                pending_resolver_owners[resolver.name] = capability.identity
 
         for domain in plugin.domains:
             self._domains[domain.identity] = DomainRegistration(

--- a/src/wilfred/capability_registry.py
+++ b/src/wilfred/capability_registry.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable
 
+from butler_core import ResolverDefinition
+
 from wilfred.capabilities import CapabilityDefinition, DomainDefinition
 
 
@@ -28,6 +30,7 @@ class CapabilityRegistry:
     def __init__(self) -> None:
         self._domains: dict[str, DomainRegistration] = {}
         self._capabilities: dict[str, CapabilityRegistration] = {}
+        self._resolver_owners: dict[str, str] = {}
 
     def register_plugin(self, plugin: PluginDefinition) -> None:
         for domain in plugin.domains:
@@ -50,6 +53,16 @@ class CapabilityRegistry:
                     f"and {plugin.name!r}."
                 )
 
+            for resolver in capability.resolvers:
+                previous_capability = self._resolver_owners.get(resolver.name)
+
+                if previous_capability is not None:
+                    raise ValueError(
+                        f"Duplicate resolver name {resolver.name!r} "
+                        f"owned by capabilities {previous_capability!r} "
+                        f"and {capability.identity!r}."
+                    )
+
         for domain in plugin.domains:
             self._domains[domain.identity] = DomainRegistration(
                 definition=domain,
@@ -61,6 +74,8 @@ class CapabilityRegistry:
                 definition=capability,
                 owner_plugin=plugin.name,
             )
+            for resolver in capability.resolvers:
+                self._resolver_owners[resolver.name] = capability.identity
 
     @classmethod
     def from_plugins(
@@ -77,6 +92,14 @@ class CapabilityRegistry:
 
     def capability_names(self) -> list[str]:
         return sorted(self._capabilities)
+
+    def resolver_definitions(self) -> tuple[ResolverDefinition, ...]:
+        """Compose capability-owned resolvers in deterministic order."""
+
+        resolvers: list[ResolverDefinition] = []
+        for _, registration in sorted(self._capabilities.items()):
+            resolvers.extend(registration.definition.resolvers)
+        return tuple(resolvers)
 
     def describe_domains(self) -> list[dict[str, str]]:
         return [

--- a/src/wilfred/runtime.py
+++ b/src/wilfred/runtime.py
@@ -49,6 +49,9 @@ class WilfredRuntime:
         registry = ToolRegistry()
         loaded_plugins = tuple(plugins)
         capability_registry = CapabilityRegistry.from_plugins(loaded_plugins)
+        legacy_resolvers = tuple(resolvers)
+        capability_resolvers = capability_registry.resolver_definitions()
+        composed_resolvers = legacy_resolvers + capability_resolvers
 
         register_native_tools(registry)
         load_plugins(registry, loaded_plugins)
@@ -64,7 +67,7 @@ class WilfredRuntime:
             model=model,
             enabled=enabled,
             policy=policy,
-            resolvers=tuple(resolvers),
+            resolvers=composed_resolvers,
             before_fallback=self._acknowledge_provider_latency,
         )
 

--- a/tests/test_capability_registry.py
+++ b/tests/test_capability_registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from butler_core import ResolutionResult, ResolverDefinition
 from wilfred import (
     CapabilityDefinition,
     CapabilityRegistry,
@@ -21,6 +22,13 @@ def _plugin(
         register=lambda registry: None,
         domains=tuple(domains),
         capabilities=tuple(capabilities),
+    )
+
+
+def _resolver(name: str) -> ResolverDefinition:
+    return ResolverDefinition(
+        name=name,
+        handler=lambda request: ResolutionResult.not_handled_result(),
     )
 
 
@@ -80,6 +88,41 @@ def test_registry_orders_semantic_metadata_deterministically():
     ]
 
 
+def test_registry_composes_resolvers_by_capability_then_declaration_order():
+    zeta = _plugin(
+        "plugin.zeta",
+        domains=[DomainDefinition(name="zeta")],
+        capabilities=[
+            CapabilityDefinition(
+                name="status",
+                domain="zeta",
+                resolvers=(
+                    _resolver("zeta.first"),
+                    _resolver("zeta.second"),
+                ),
+            )
+        ],
+    )
+    alpha = _plugin(
+        "plugin.alpha",
+        domains=[DomainDefinition(name="alpha")],
+        capabilities=[
+            CapabilityDefinition(
+                name="status",
+                domain="alpha",
+                resolvers=(_resolver("alpha.only"),),
+            )
+        ],
+    )
+
+    registry = CapabilityRegistry.from_plugins([zeta, alpha])
+
+    assert [
+        resolver.name
+        for resolver in registry.resolver_definitions()
+    ] == ["alpha.only", "zeta.first", "zeta.second"]
+
+
 def test_registry_rejects_duplicate_domain_identity():
     first = _plugin(
         "plugin.first",
@@ -97,6 +140,31 @@ def test_registry_rejects_duplicate_domain_identity():
         CapabilityRegistry.from_plugins([first, second])
 
 
+def test_registry_rejects_duplicate_resolver_name_across_capabilities():
+    plugin = _plugin(
+        "plugin.media",
+        domains=[DomainDefinition(name="media")],
+        capabilities=[
+            CapabilityDefinition(
+                name="playback",
+                domain="media",
+                resolvers=(_resolver("media.shared"),),
+            ),
+            CapabilityDefinition(
+                name="search",
+                domain="media",
+                resolvers=(_resolver("media.shared"),),
+            ),
+        ],
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Duplicate resolver name 'media.shared'.*'media.playback'.*'media.search'",
+    ):
+        CapabilityRegistry.from_plugins([plugin])
+
+
 def test_tool_only_plugin_has_empty_semantic_view():
     registry = CapabilityRegistry.from_plugins([
         _plugin("plugin.legacy")
@@ -104,3 +172,4 @@ def test_tool_only_plugin_has_empty_semantic_view():
 
     assert registry.domain_names() == []
     assert registry.capability_names() == []
+    assert registry.resolver_definitions() == ()

--- a/tests/test_capability_resolvers.py
+++ b/tests/test_capability_resolvers.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+
+from butler_core import (
+    ExecutionStatus,
+    PlannerResult,
+    PlannerStatus,
+    ResolutionResult,
+    ResolverDefinition,
+    ToolPlan,
+)
+
+from wilfred import CapabilityDefinition, DomainDefinition, WilfredRuntime
+from wilfred.models import ToolDefinition, ToolPermission
+from wilfred.plugins import PluginDefinition
+
+
+def _plan(tool_name: str, reason: str) -> PlannerResult:
+    return PlannerResult(
+        status=PlannerStatus.SUCCESS,
+        duration_ms=0.0,
+        plan=ToolPlan(
+            tool_name=tool_name,
+            arguments={},
+            confidence=1.0,
+            reason=reason,
+        ),
+    )
+
+
+def _plugin(
+    *,
+    plugin_name: str,
+    domain_name: str,
+    capability_name: str,
+    resolver: ResolverDefinition,
+    tool_name: str,
+    permission: ToolPermission = ToolPermission.READ,
+) -> PluginDefinition:
+    def register(registry) -> None:
+        registry.register(
+            ToolDefinition(
+                name=tool_name,
+                description=f"Test tool {tool_name}.",
+                handler=lambda: {"tool": tool_name},
+                permission=permission,
+            )
+        )
+
+    return PluginDefinition(
+        name=plugin_name,
+        register=register,
+        domains=(DomainDefinition(name=domain_name),),
+        capabilities=(
+            CapabilityDefinition(
+                name=capability_name,
+                domain=domain_name,
+                resolvers=(resolver,),
+            ),
+        ),
+    )
+
+
+def test_capability_owned_resolver_skips_planner_provider() -> None:
+    provider_calls: list[str] = []
+
+    def provider(message, prompt, tools):
+        provider_calls.append(message)
+        raise AssertionError("planner provider must not be called")
+
+    plugin = _plugin(
+        plugin_name="plugin.media",
+        domain_name="media",
+        capability_name="playback",
+        resolver=ResolverDefinition(
+            name="media.playback.local",
+            handler=lambda message: ResolutionResult.handled_result(
+                _plan("play_media", "capability resolver")
+            ),
+        ),
+        tool_name="play_media",
+    )
+
+    runtime = WilfredRuntime(
+        provider=provider,
+        system_prompt="Test.",
+        plugins=(plugin,),
+    )
+
+    result = runtime.execute_goal("play locally")
+
+    assert provider_calls == []
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.SUCCESS
+    assert result.execution.value == {"tool": "play_media"}
+    assert result.planning.plan is not None
+    assert result.planning.plan.reason == "capability resolver"
+
+
+def test_capability_resolver_order_is_deterministic() -> None:
+    calls: list[str] = []
+
+    def alpha_resolver(message):
+        calls.append("alpha")
+        return ResolutionResult.not_handled_result()
+
+    def zeta_resolver(message):
+        calls.append("zeta")
+        return ResolutionResult.handled_result(
+            _plan("zeta_tool", "zeta handled")
+        )
+
+    alpha = _plugin(
+        plugin_name="plugin.alpha",
+        domain_name="alpha",
+        capability_name="status",
+        resolver=ResolverDefinition("alpha.status", alpha_resolver),
+        tool_name="alpha_tool",
+    )
+    zeta = _plugin(
+        plugin_name="plugin.zeta",
+        domain_name="zeta",
+        capability_name="status",
+        resolver=ResolverDefinition("zeta.status", zeta_resolver),
+        tool_name="zeta_tool",
+    )
+
+    runtime = WilfredRuntime(
+        provider=lambda *args: (_ for _ in ()).throw(
+            AssertionError("planner provider must not be called")
+        ),
+        system_prompt="Test.",
+        plugins=(zeta, alpha),
+    )
+
+    result = runtime.execute_goal("status")
+
+    assert calls == ["alpha", "zeta"]
+    assert result.execution is not None
+    assert result.execution.value == {"tool": "zeta_tool"}
+
+
+def test_legacy_runtime_resolvers_keep_precedence() -> None:
+    capability_calls: list[str] = []
+
+    def capability_resolver(message):
+        capability_calls.append(message)
+        return ResolutionResult.handled_result(
+            _plan("read_state", "capability")
+        )
+
+    plugin = _plugin(
+        plugin_name="plugin.state",
+        domain_name="state",
+        capability_name="read",
+        resolver=ResolverDefinition("state.read", capability_resolver),
+        tool_name="read_state",
+    )
+    legacy = ResolverDefinition(
+        name="legacy.read",
+        handler=lambda message: ResolutionResult.handled_result(
+            _plan("read_state", "legacy")
+        ),
+    )
+
+    runtime = WilfredRuntime(
+        provider=lambda *args: "{}",
+        system_prompt="Test.",
+        plugins=(plugin,),
+        resolvers=(legacy,),
+    )
+
+    result = runtime.execute_goal("read")
+
+    assert capability_calls == []
+    assert result.planning.plan is not None
+    assert result.planning.plan.reason == "legacy"
+
+
+def test_capability_decline_preserves_planner_fallback() -> None:
+    provider_calls: list[str] = []
+
+    def provider(message, prompt, tools):
+        provider_calls.append(message)
+        return json.dumps(
+            {
+                "tool_name": "read_state",
+                "arguments": {},
+                "confidence": 1.0,
+                "reason": "planner fallback",
+            }
+        )
+
+    plugin = _plugin(
+        plugin_name="plugin.state",
+        domain_name="state",
+        capability_name="read",
+        resolver=ResolverDefinition(
+            "state.read",
+            lambda message: ResolutionResult.not_handled_result(),
+        ),
+        tool_name="read_state",
+    )
+
+    runtime = WilfredRuntime(
+        provider=provider,
+        system_prompt="Test.",
+        plugins=(plugin,),
+    )
+
+    result = runtime.execute_goal("use planner")
+
+    assert provider_calls == ["use planner"]
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.SUCCESS
+
+
+def test_capability_resolver_cannot_bypass_action_confirmation() -> None:
+    plugin = _plugin(
+        plugin_name="plugin.action",
+        domain_name="action",
+        capability_name="run",
+        resolver=ResolverDefinition(
+            "action.run",
+            lambda message: ResolutionResult.handled_result(
+                _plan("dangerous_action", "capability action")
+            ),
+        ),
+        tool_name="dangerous_action",
+        permission=ToolPermission.ACTION,
+    )
+
+    runtime = WilfredRuntime(
+        provider=lambda *args: "{}",
+        system_prompt="Test.",
+        plugins=(plugin,),
+    )
+
+    result = runtime.execute_goal("do it")
+
+    assert result.execution is not None
+    assert result.execution.status is ExecutionStatus.CONFIRMATION_REQUIRED


### PR DESCRIPTION
## Summary

Capability definitions can own ordered deterministic resolvers. Wilfred composes them by capability identity while preserving the existing runtime resolver parameter as the compatibility path. Planner fallback and the existing execution-policy path remain unchanged.

Includes focused tests and public documentation.

Closes #38.