### PR TITLE
WILF-057: expose capability discovery through CLI and HTTP

### DIFF
--- a/docs/http-api.md
+++ b/docs/http-api.md
@@ -65,12 +65,50 @@ Returns transport liveness without calling a planner provider:
 
 ### GET /v1/runtime
 
-Returns credential-free runtime metadata and the registered tool count.
+Returns credential-free runtime metadata including registered tool, domain and
+capability counts.
 
 ### GET /v1/tools
 
 Returns deterministic public tool descriptions, including parameter schemas
 and permissions. Python handlers are never exposed.
+
+### GET /v1/domains
+
+Returns deterministic domain metadata from the loaded capability registry:
+
+```json
+{
+  "domains": [
+    {
+      "name": "media",
+      "description": "Media discovery and playback.",
+      "owner_plugin": "example.media"
+    }
+  ]
+}
+```
+
+### GET /v1/capabilities
+
+Returns deterministic, sanitized capability metadata:
+
+```json
+{
+  "capabilities": [
+    {
+      "name": "media.playback",
+      "domain": "media",
+      "description": "Play resolved media.",
+      "owner_plugin": "example.media"
+    }
+  ]
+}
+```
+
+Discovery responses expose semantic metadata only. Resolver handlers, provider
+configuration, credentials and private runtime payloads are not part of the
+schema.
 
 ### POST /v1/goals
 
@@ -118,6 +156,20 @@ The response preserves the shared structured planning and execution result:
   }
 }
 ```
+
+## CLI discovery
+
+Capability discovery is also available without starting the HTTP transport or
+configuring a planner:
+
+```bash
+wilfred domains
+wilfred capabilities
+```
+
+Configured plugins can be supplied with repeated `--plugin MODULE:FACTORY`
+arguments or through `WILFRED_PLUGINS`. These commands load plugin declarations
+for introspection but do not call a planner provider.
 
 ## Confirmation boundary
 

--- a/src/wilfred/__main__.py
+++ b/src/wilfred/__main__.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import sys
 
 from wilfred import __version__
+from wilfred.capability_registry import CapabilityRegistry
 from wilfred.config import (
     ConfigurationError,
     RuntimeConfig,
@@ -47,7 +48,6 @@ def _api_port(value: str) -> int:
     return port
 
 
-
 def _plugin_specs(
     cli_values: Sequence[str],
     environ: Mapping[str, str],
@@ -74,6 +74,18 @@ def _plugin_specs(
         )
     )
 
+
+def _add_plugin_argument(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--plugin",
+        action="append",
+        default=[],
+        metavar="MODULE:FACTORY",
+        help=(
+            "Load a configured plugin factory. "
+            "May be repeated."
+        ),
+    )
 
 
 def runtime_status(
@@ -131,8 +143,20 @@ def build_parser() -> argparse.ArgumentParser:
     )
     commands.add_parser(
         "tools",
-        help="List Wilfred native capabilities.",
+        help="List Wilfred native tools.",
     )
+
+    domains = commands.add_parser(
+        "domains",
+        help="List domains declared by configured plugins.",
+    )
+    _add_plugin_argument(domains)
+
+    capabilities = commands.add_parser(
+        "capabilities",
+        help="List capabilities declared by configured plugins.",
+    )
+    _add_plugin_argument(capabilities)
 
     goal = commands.add_parser(
         "goal",
@@ -153,16 +177,7 @@ def build_parser() -> argparse.ArgumentParser:
         required=True,
         help="Provider model identifier.",
     )
-    goal.add_argument(
-        "--plugin",
-        action="append",
-        default=[],
-        metavar="MODULE:FACTORY",
-        help=(
-            "Load a configured plugin factory. "
-            "May be repeated."
-        ),
-    )
+    _add_plugin_argument(goal)
 
     goal.add_argument(
         "--confirmed",
@@ -177,16 +192,7 @@ def build_parser() -> argparse.ArgumentParser:
             "Serve the goal runtime through the optional HTTP API."
         ),
     )
-    api.add_argument(
-        "--plugin",
-        action="append",
-        default=[],
-        metavar="MODULE:FACTORY",
-        help=(
-            "Load a configured plugin factory. "
-            "May be repeated."
-        ),
-    )
+    _add_plugin_argument(api)
 
     api.add_argument(
         "--provider",
@@ -242,6 +248,34 @@ def run_native_command(command: str) -> int:
     print(
         json.dumps(
             result.value,
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def run_discovery_command(
+    *,
+    command: str,
+    plugin_specs: Sequence[str],
+    environ: Mapping[str, str],
+) -> int:
+    plugins = discover_configured_plugins(
+        plugin_specs,
+        environ=environ,
+    )
+    registry = CapabilityRegistry.from_plugins(plugins)
+
+    payload = (
+        {"domains": registry.describe_domains()}
+        if command == "domains"
+        else {"capabilities": registry.describe_capabilities()}
+    )
+
+    print(
+        json.dumps(
+            payload,
             ensure_ascii=False,
             sort_keys=True,
         )
@@ -370,6 +404,21 @@ def main(
 
     if arguments.command in {"status", "tools"}:
         return run_native_command(arguments.command)
+
+    if arguments.command in {"domains", "capabilities"}:
+        effective_environment = (
+            os.environ
+            if environ is None
+            else environ
+        )
+        return run_discovery_command(
+            command=arguments.command,
+            plugin_specs=_plugin_specs(
+                arguments.plugin,
+                effective_environment,
+            ),
+            environ=effective_environment,
+        )
 
     if arguments.command == "goal":
         effective_environment = (

--- a/src/wilfred/api.py
+++ b/src/wilfred/api.py
@@ -50,6 +50,8 @@ class RuntimeResponse(BaseModel):
     version: str
     runtime: str
     tool_count: int
+    domain_count: int
+    capability_count: int
 
 
 class ToolResponse(BaseModel):
@@ -62,6 +64,27 @@ class ToolResponse(BaseModel):
 
 class ToolsResponse(BaseModel):
     tools: list[ToolResponse]
+
+
+class DomainResponse(BaseModel):
+    name: str
+    description: str
+    owner_plugin: str
+
+
+class DomainsResponse(BaseModel):
+    domains: list[DomainResponse]
+
+
+class CapabilityResponse(BaseModel):
+    name: str
+    domain: str
+    description: str
+    owner_plugin: str
+
+
+class CapabilitiesResponse(BaseModel):
+    capabilities: list[CapabilityResponse]
 
 
 class GoalRequest(BaseModel):
@@ -282,6 +305,22 @@ def create_app(
     def tools() -> dict[str, object]:
         return {"tools": runtime.describe_tools()}
 
+    @app.get(
+        "/v1/domains",
+        response_model=DomainsResponse,
+        tags=["runtime"],
+    )
+    def domains() -> dict[str, object]:
+        return {"domains": runtime.describe_domains()}
+
+    @app.get(
+        "/v1/capabilities",
+        response_model=CapabilitiesResponse,
+        tags=["runtime"],
+    )
+    def capabilities() -> dict[str, object]:
+        return {"capabilities": runtime.describe_capabilities()}
+
     @app.post(
         "/v1/goals",
         response_model=GoalResponse,
@@ -348,8 +387,10 @@ def serve_api(
 
 
 __all__ = [
+    "CapabilitiesResponse",
     "DEFAULT_HOST",
     "DEFAULT_PORT",
+    "DomainsResponse",
     "GoalRequest",
     "GoalResponse",
     "HTTPAPIUnavailableError",

--- a/tests/test_capability_discovery_http.py
+++ b/tests/test_capability_discovery_http.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+
+from fastapi.testclient import TestClient
+
+from wilfred import CapabilityDefinition, DomainDefinition, WilfredRuntime
+from wilfred.api import create_app
+from wilfred.models import ToolDefinition
+from wilfred.plugins import PluginDefinition
+
+
+def _provider(message, system_prompt, tools):
+    return json.dumps(
+        {
+            "tool_name": "media_status",
+            "arguments": {},
+            "confidence": 1.0,
+            "reason": "test",
+        }
+    )
+
+
+def _runtime() -> WilfredRuntime:
+    def register(registry) -> None:
+        registry.register(
+            ToolDefinition(
+                name="media_status",
+                description="Read media status.",
+                handler=lambda: {"status": "ok"},
+            )
+        )
+
+    plugin = PluginDefinition(
+        name="test.media",
+        register=register,
+        domains=(
+            DomainDefinition(
+                name="media",
+                description="Media domain.",
+            ),
+        ),
+        capabilities=(
+            CapabilityDefinition(
+                name="playback",
+                domain="media",
+                description="Play media.",
+            ),
+        ),
+    )
+
+    return WilfredRuntime(
+        provider=_provider,
+        system_prompt="Test capability discovery.",
+        plugins=(plugin,),
+    )
+
+
+def test_http_exposes_sanitized_domain_and_capability_discovery() -> None:
+    client = TestClient(create_app(_runtime()))
+
+    runtime = client.get("/v1/runtime")
+    domains = client.get("/v1/domains")
+    capabilities = client.get("/v1/capabilities")
+
+    assert runtime.status_code == 200
+    assert runtime.json()["domain_count"] == 1
+    assert runtime.json()["capability_count"] == 1
+
+    assert domains.status_code == 200
+    assert domains.json() == {
+        "domains": [
+            {
+                "name": "media",
+                "description": "Media domain.",
+                "owner_plugin": "test.media",
+            }
+        ]
+    }
+
+    assert capabilities.status_code == 200
+    assert capabilities.json() == {
+        "capabilities": [
+            {
+                "name": "media.playback",
+                "domain": "media",
+                "description": "Play media.",
+                "owner_plugin": "test.media",
+            }
+        ]
+    }
+
+    capability = capabilities.json()["capabilities"][0]
+    assert set(capability) == {
+        "name",
+        "domain",
+        "description",
+        "owner_plugin",
+    }
+
+
+def test_openapi_advertises_discovery_endpoints() -> None:
+    client = TestClient(create_app(_runtime()))
+
+    paths = client.get("/openapi.json").json()["paths"]
+
+    assert "/v1/domains" in paths
+    assert "/v1/capabilities" in paths

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,9 @@ from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 import json
 
+from wilfred import CapabilityDefinition, DomainDefinition
 from wilfred.__main__ import main
+from wilfred.plugins import PluginDefinition
 
 
 def run_cli(arguments: list[str]) -> tuple[int, str, str]:
@@ -41,6 +43,78 @@ def test_tools_command() -> None:
         "wilfred_status",
         "wilfred_tools",
     ]
+
+
+def test_domains_and_capabilities_commands_expose_plugin_metadata(
+    monkeypatch,
+) -> None:
+    plugin = PluginDefinition(
+        name="test.media",
+        register=lambda registry: None,
+        domains=(
+            DomainDefinition(
+                name="media",
+                description="Media domain.",
+            ),
+        ),
+        capabilities=(
+            CapabilityDefinition(
+                name="playback",
+                domain="media",
+                description="Play media.",
+            ),
+        ),
+    )
+
+    monkeypatch.setattr(
+        "wilfred.__main__.discover_configured_plugins",
+        lambda specs, environ: [plugin],
+    )
+
+    domains_result, domains_output, domains_errors = run_cli(
+        ["domains", "--plugin", "test:factory"]
+    )
+    capabilities_result, capabilities_output, capabilities_errors = run_cli(
+        ["capabilities", "--plugin", "test:factory"]
+    )
+
+    assert domains_result == 0
+    assert capabilities_result == 0
+    assert domains_errors == ""
+    assert capabilities_errors == ""
+    assert json.loads(domains_output) == {
+        "domains": [
+            {
+                "name": "media",
+                "description": "Media domain.",
+                "owner_plugin": "test.media",
+            }
+        ]
+    }
+    assert json.loads(capabilities_output) == {
+        "capabilities": [
+            {
+                "name": "media.playback",
+                "domain": "media",
+                "description": "Play media.",
+                "owner_plugin": "test.media",
+            }
+        ]
+    }
+
+
+def test_discovery_commands_do_not_require_planner_configuration() -> None:
+    domains_result, domains_output, domains_errors = run_cli(["domains"])
+    capabilities_result, capabilities_output, capabilities_errors = run_cli(
+        ["capabilities"]
+    )
+
+    assert domains_result == 0
+    assert capabilities_result == 0
+    assert domains_errors == ""
+    assert capabilities_errors == ""
+    assert json.loads(domains_output) == {"domains": []}
+    assert json.loads(capabilities_output) == {"capabilities": []}
 
 
 def test_no_command_preserves_existing_cli() -> None:


### PR DESCRIPTION
## Summary

Expose loaded domains and capabilities through provider-neutral CLI discovery commands and typed HTTP endpoints. Runtime metadata now includes domain and capability counts, while discovery responses remain limited to sanitized semantic metadata.

Includes transport tests and public documentation.

Closes #39.