### PR TITLE
feat: add plugin-declared verification contributions [WILF-062]

### DIFF
--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -16,6 +16,7 @@ Each layer has one job.
 - **Capability** names something the Butler knows how to do inside that domain. The reference plugin declares `demo.echo`.
 - **Resolver** deterministically recognizes goals that the capability can handle and produces a normal tool plan. The reference resolver is `demo.echo.text`.
 - **Tool** is the typed executable operation. The reference tool is `demo_echo` and is classified `READ`.
+- **Verification contribution** declares behavior that the plugin promises should remain true. Wilfred owns the harness that executes those expectations.
 
 The capability registry and tool registry remain separate. Semantic ownership does not make a capability executable by itself, and executable tools do not implicitly define semantic ownership.
 
@@ -82,7 +83,25 @@ def resolve_demo_echo(message: str) -> ResolutionResult:
     )
 ```
 
-Finally the plugin declares both executable and semantic contributions:
+The same plugin can declare deterministic verification expectations without embedding pytest or arbitrary executable test callbacks:
+
+```python
+demo_echo_expectation = GoalExpectation(
+    identity="demo.echo.basic",
+    goal="echo hello from verification",
+    capability="demo.echo",
+    tool_name="demo_echo",
+    expected_arguments={
+        "message": "hello from verification",
+    },
+    expected_value={
+        "message": "hello from verification",
+    },
+    verify_value=True,
+)
+```
+
+Finally the plugin declares executable, semantic and verification contributions together:
 
 ```python
 plugin = PluginDefinition(
@@ -90,6 +109,7 @@ plugin = PluginDefinition(
     register=register_demo_echo_tools,
     domains=(demo_domain,),
     capabilities=(demo_echo_capability,),
+    verification=(demo_echo_expectation,),
 )
 ```
 
@@ -127,6 +147,25 @@ result = runtime.execute_goal("echo hello")
 
 `demo.echo.text` resolves the goal before planner fallback, but the resulting `demo_echo` tool still executes through the normal Execution Engine and permission policy.
 
+## Verify declared expectations
+
+Verification declarations describe expected behavior. They do not execute during plugin import or normal runtime composition.
+
+A shared harness collects them from the loaded plugin set and executes deterministic goals through the normal `WilfredRuntime` path:
+
+```python
+from wilfred import discover_plugins, verify_plugins
+
+plugins = discover_plugins(["wilfred.plugins.demo_echo"])
+results = verify_plugins(plugins)
+
+assert results[0].passed is True
+```
+
+Each `VerificationResult` contains the expectation ID, plugin name, PASS/FAIL state and deterministic diagnostics. Duplicate expectation identities within one plugin are rejected when the `PluginDefinition` is constructed. Expectations must reference capabilities owned by that same plugin.
+
+This first public contract is intentionally provider-neutral and goal-level. Frontend-specific regression data belongs to the frontend that owns it. A future Alexa frontend, for example, may compose utterance expectations with the same principle without introducing Alexa intents, slots or SMAPI concepts into Butler Core or Wilfred's provider-neutral runtime.
+
 ## Authoring rules
 
 Keep these boundaries stable when creating a real plugin:
@@ -137,8 +176,9 @@ Keep these boundaries stable when creating a real plugin:
 4. Put deterministic recognition beside the capability that owns it.
 5. Return `NOT_HANDLED` when the resolver cannot confidently own a goal.
 6. Never bypass Execution Engine policy, confirmation or post-action verification from a resolver.
-7. Keep frontend presentation and provider-specific rendering outside Butler Core.
-8. Do not put secrets, private endpoints or deployment-specific identifiers in public plugin metadata.
+7. Declare representative deterministic expectations instead of embedding test-framework execution in plugin import paths.
+8. Keep frontend presentation and provider-specific rendering outside Butler Core.
+9. Do not put secrets, private endpoints or deployment-specific identifiers in public plugin metadata or verification declarations.
 
 ## Testing a plugin
 
@@ -148,11 +188,13 @@ A useful plugin test set should prove at least:
 - tools register deterministically;
 - domain and capability identities are reported by `PluginLoadResult`;
 - deterministic goals resolve through capability-owned resolvers;
+- declared verification expectations pass through the shared harness;
+- expectation mismatches produce structured failures;
 - unhandled goals preserve planner fallback;
 - ACTION or DANGEROUS tools still require the normal policy/confirmation path;
 - installation from a built wheel works in a clean environment.
 
-Wilfred's own `tests/test_plugins.py`, capability resolver tests and clean-room distribution test exercise those boundaries for the reference plugin.
+Wilfred's own plugin, capability resolver, verification and clean-room distribution tests exercise those boundaries for the reference plugin.
 
 ## From the reference plugin to a real integration
 

--- a/src/wilfred/__init__.py
+++ b/src/wilfred/__init__.py
@@ -52,6 +52,11 @@ from wilfred.plugins import (
     load_plugins,
 )
 from wilfred.registry import ToolRegistry
+from wilfred.verification import (
+    GoalExpectation,
+    VerificationResult,
+    verify_plugins,
+)
 from wilfred.workflows import (
     ReadActionVerifyRequest,
     ReadActionVerifyResult,
@@ -78,6 +83,7 @@ __all__ = [
     "ExecutionRequest",
     "ExecutionResult",
     "ExecutionStatus",
+    "GoalExpectation",
     "OutputAdapter",
     "OutputCapability",
     "OutputDeliveryResult",
@@ -98,6 +104,7 @@ __all__ = [
     "ToolDefinition",
     "ToolPermission",
     "ToolRegistry",
+    "VerificationResult",
     "VerificationStatus",
     "WorkflowPersistenceError",
     "WorkflowRecord",
@@ -107,5 +114,6 @@ __all__ = [
     "load_plugin",
     "load_plugins",
     "validate_arguments",
+    "verify_plugins",
     "__version__",
 ]

--- a/src/wilfred/plugins/contracts.py
+++ b/src/wilfred/plugins/contracts.py
@@ -8,6 +8,7 @@ from wilfred.capabilities import (
     CapabilityDefinition,
     DomainDefinition,
 )
+from wilfred.verification import GoalExpectation
 
 
 if TYPE_CHECKING:
@@ -29,6 +30,7 @@ class PluginDefinition:
     version: str = "0.1.0"
     domains: tuple[DomainDefinition, ...] = ()
     capabilities: tuple[CapabilityDefinition, ...] = ()
+    verification: tuple[GoalExpectation, ...] = ()
 
     def __post_init__(self) -> None:
         if _PLUGIN_NAME_PATTERN.fullmatch(self.name) is None:
@@ -49,6 +51,7 @@ class PluginDefinition:
 
         domains = tuple(self.domains)
         capabilities = tuple(self.capabilities)
+        verification = tuple(self.verification)
 
         if not all(
             isinstance(domain, DomainDefinition)
@@ -64,6 +67,14 @@ class PluginDefinition:
         ):
             raise TypeError(
                 "Plugin capabilities must contain CapabilityDefinition values."
+            )
+
+        if not all(
+            isinstance(expectation, GoalExpectation)
+            for expectation in verification
+        ):
+            raise TypeError(
+                "Plugin verification must contain GoalExpectation values."
             )
 
         domain_names = [domain.identity for domain in domains]
@@ -95,7 +106,24 @@ class PluginDefinition:
                 f"{', '.join(duplicate_capabilities)}"
             )
 
+        verification_names = [
+            expectation.identity
+            for expectation in verification
+        ]
+        duplicate_verification = sorted(
+            name
+            for name in set(verification_names)
+            if verification_names.count(name) > 1
+        )
+
+        if duplicate_verification:
+            raise ValueError(
+                f"Plugin {self.name!r} declares duplicate verification expectations: "
+                f"{', '.join(duplicate_verification)}"
+            )
+
         owned_domains = set(domain_names)
+        owned_capabilities = set(capability_names)
 
         for capability in capabilities:
             if capability.domain not in owned_domains:
@@ -103,6 +131,14 @@ class PluginDefinition:
                     f"Plugin {self.name!r} capability "
                     f"{capability.identity!r} references undeclared domain "
                     f"{capability.domain!r}."
+                )
+
+        for expectation in verification:
+            if expectation.capability not in owned_capabilities:
+                raise ValueError(
+                    f"Plugin {self.name!r} verification expectation "
+                    f"{expectation.identity!r} references undeclared capability "
+                    f"{expectation.capability!r}."
                 )
 
         object.__setattr__(
@@ -117,6 +153,16 @@ class PluginDefinition:
                 sorted(
                     capabilities,
                     key=lambda capability: capability.identity,
+                )
+            ),
+        )
+        object.__setattr__(
+            self,
+            "verification",
+            tuple(
+                sorted(
+                    verification,
+                    key=lambda expectation: expectation.identity,
                 )
             ),
         )

--- a/src/wilfred/plugins/demo_echo.py
+++ b/src/wilfred/plugins/demo_echo.py
@@ -20,6 +20,7 @@ from wilfred.models import (
 )
 from wilfred.plugins.contracts import PluginDefinition
 from wilfred.registry import ToolRegistry
+from wilfred.verification import GoalExpectation
 
 
 class EchoProvider(Protocol):
@@ -119,6 +120,21 @@ demo_echo_capability = CapabilityDefinition(
 )
 
 
+demo_echo_expectation = GoalExpectation(
+    identity="demo.echo.basic",
+    goal="echo hello from verification",
+    capability="demo.echo",
+    tool_name="demo_echo",
+    expected_arguments={
+        "message": "hello from verification",
+    },
+    expected_value={
+        "message": "hello from verification",
+    },
+    verify_value=True,
+)
+
+
 plugin = PluginDefinition(
     name="demo.echo",
     version="0.1.0",
@@ -128,4 +144,5 @@ plugin = PluginDefinition(
     register=register_demo_echo_tools,
     domains=(demo_domain,),
     capabilities=(demo_echo_capability,),
+    verification=(demo_echo_expectation,),
 )

--- a/src/wilfred/verification.py
+++ b/src/wilfred/verification.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Iterable, Mapping
+
+from butler_core import ExecutionStatus
+
+if TYPE_CHECKING:
+    from wilfred.plugins import PluginDefinition
+
+
+@dataclass(frozen=True)
+class GoalExpectation:
+    """Declarative deterministic goal expectation owned by a plugin."""
+
+    identity: str
+    goal: str
+    capability: str
+    tool_name: str
+    expected_arguments: Mapping[str, object] | None = None
+    expected_value: object | None = None
+    verify_value: bool = False
+
+    def __post_init__(self) -> None:
+        for field_name, value in (
+            ("identity", self.identity),
+            ("goal", self.goal),
+            ("capability", self.capability),
+            ("tool_name", self.tool_name),
+        ):
+            if not value.strip():
+                raise ValueError(f"{field_name} cannot be empty.")
+
+        if self.expected_arguments is not None:
+            object.__setattr__(
+                self,
+                "expected_arguments",
+                dict(self.expected_arguments),
+            )
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    expectation_id: str
+    plugin_name: str
+    passed: bool
+    diagnostics: tuple[str, ...] = ()
+
+
+def verify_plugins(
+    plugins: Iterable["PluginDefinition"],
+) -> tuple[VerificationResult, ...]:
+    """Execute plugin-declared deterministic expectations through WilfredRuntime."""
+
+    from wilfred.runtime import WilfredRuntime
+
+    loaded_plugins = tuple(plugins)
+
+    def unexpected_planner(*args: object, **kwargs: object) -> str:
+        raise RuntimeError("planner fallback was used")
+
+    runtime = WilfredRuntime(
+        provider=unexpected_planner,
+        system_prompt="Plugin verification harness.",
+        plugins=loaded_plugins,
+    )
+
+    results: list[VerificationResult] = []
+
+    for plugin in sorted(loaded_plugins, key=lambda item: item.name):
+        owned_capabilities = {
+            capability.identity for capability in plugin.capabilities
+        }
+
+        for expectation in plugin.verification:
+            diagnostics: list[str] = []
+
+            if expectation.capability not in owned_capabilities:
+                diagnostics.append(
+                    "expectation references capability not owned by plugin: "
+                    f"{expectation.capability}"
+                )
+
+            if not diagnostics:
+                try:
+                    outcome = runtime.execute_goal(expectation.goal)
+                except Exception as exc:
+                    diagnostics.append(
+                        f"runtime execution failed: {type(exc).__name__}: {exc}"
+                    )
+                else:
+                    plan = outcome.planning.plan
+                    if plan is None:
+                        diagnostics.append("goal produced no tool plan")
+                    else:
+                        if plan.tool_name != expectation.tool_name:
+                            diagnostics.append(
+                                "tool mismatch: "
+                                f"expected {expectation.tool_name}, got {plan.tool_name}"
+                            )
+                        if expectation.expected_arguments is not None and dict(
+                            plan.arguments
+                        ) != dict(expectation.expected_arguments):
+                            diagnostics.append(
+                                "arguments mismatch: "
+                                f"expected {dict(expectation.expected_arguments)!r}, "
+                                f"got {dict(plan.arguments)!r}"
+                            )
+
+                    execution = outcome.execution
+                    if execution is None:
+                        diagnostics.append("goal was not executed")
+                    elif execution.status is not ExecutionStatus.SUCCESS:
+                        diagnostics.append(
+                            "execution status mismatch: "
+                            f"expected success, got {execution.status.value}"
+                        )
+                    elif expectation.verify_value and (
+                        execution.value != expectation.expected_value
+                    ):
+                        diagnostics.append(
+                            "value mismatch: "
+                            f"expected {expectation.expected_value!r}, "
+                            f"got {execution.value!r}"
+                        )
+
+            results.append(
+                VerificationResult(
+                    expectation_id=expectation.identity,
+                    plugin_name=plugin.name,
+                    passed=not diagnostics,
+                    diagnostics=tuple(diagnostics),
+                )
+            )
+
+    return tuple(results)
+
+
+__all__ = [
+    "GoalExpectation",
+    "VerificationResult",
+    "verify_plugins",
+]

--- a/tests/test_plugin_verification.py
+++ b/tests/test_plugin_verification.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from wilfred import GoalExpectation, verify_plugins
+from wilfred.plugins.demo_echo import plugin as demo_echo_plugin
+
+
+def test_demo_echo_declares_passing_verification() -> None:
+    results = verify_plugins((demo_echo_plugin,))
+
+    assert len(results) == 1
+    assert results[0].expectation_id == "demo.echo.basic"
+    assert results[0].plugin_name == "demo.echo"
+    assert results[0].passed is True
+    assert results[0].diagnostics == ()
+
+
+def test_mismatched_expectation_returns_structured_failure() -> None:
+    failing = GoalExpectation(
+        identity="demo.echo.mismatch",
+        goal="echo hello",
+        capability="demo.echo",
+        tool_name="not_demo_echo",
+    )
+    plugin = replace(
+        demo_echo_plugin,
+        verification=(failing,),
+    )
+
+    results = verify_plugins((plugin,))
+
+    assert len(results) == 1
+    assert results[0].passed is False
+    assert results[0].diagnostics == (
+        "tool mismatch: expected not_demo_echo, got demo_echo",
+    )
+
+
+def test_duplicate_expectation_identity_is_rejected() -> None:
+    expectation = GoalExpectation(
+        identity="demo.echo.duplicate",
+        goal="echo hello",
+        capability="demo.echo",
+        tool_name="demo_echo",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="duplicate verification expectations",
+    ):
+        replace(
+            demo_echo_plugin,
+            verification=(expectation, expectation),
+        )
+
+
+def test_plugin_without_verification_remains_compatible() -> None:
+    plugin = replace(
+        demo_echo_plugin,
+        verification=(),
+    )
+
+    assert verify_plugins((plugin,)) == ()


### PR DESCRIPTION
## Summary

Add a provider-neutral verification contribution contract so plugins can declare deterministic behavior they promise to preserve, while Wilfred owns the shared execution harness.

## Changes

- add public `GoalExpectation`, `VerificationResult` and `verify_plugins()` APIs;
- let `PluginDefinition` declare deterministic verification expectations;
- reject duplicate expectation identities and expectations that reference capabilities not owned by the plugin;
- execute declared expectations through the normal `WilfredRuntime` resolution/execution path with planner fallback treated as a failure;
- make `demo.echo` the first self-verifying reference plugin;
- cover passing, failing, duplicate and no-verification cases;
- document runtime contributions vs verification contributions and the future frontend-specific extension path.

## Boundary

- plugins declare expectations but do not execute pytest/unittest or arbitrary test callbacks;
- Butler Core remains unaware of Wilfred plugin verification concepts;
- frontend-specific utterance/platform expectations remain frontend-owned;
- no real-device or external-system action testing is introduced by this tranche.

Closes #101