### PR TITLE
WILF-064: release Wilfred 0.2.2 with immutable BOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,15 +62,32 @@ jobs:
           test "$PACKAGE_VERSION" = "$VERSION"
 
           RELEASE_NOTES="docs/releases/${VERSION}.md"
+          RELEASE_BOM="distribution/releases/${VERSION}.toml"
 
           test -s "$RELEASE_NOTES"
           grep -Fq "# Wilfred $VERSION" "$RELEASE_NOTES"
+
+          test -s "$RELEASE_BOM"
+          cmp -s distribution/bom.toml "$RELEASE_BOM"
+
+          python - "$VERSION" "$TAG" "$RELEASE_BOM" <<'PY'
+          import sys
+          import tomllib
+          from pathlib import Path
+
+          version, tag, path = sys.argv[1:]
+          data = tomllib.loads(Path(path).read_text(encoding="utf-8"))
+          assert data["components"]["wilfred"]["version"] == version
+          assert data["release"] == version
+          assert data["source_tag"] == tag
+          PY
 
           git fetch origin main:refs/remotes/origin/main
           git merge-base --is-ancestor HEAD origin/main
 
           echo "RELEASE_VERSION=$VERSION" >> "$GITHUB_ENV"
           echo "RELEASE_NOTES=$RELEASE_NOTES" >> "$GITHUB_ENV"
+          echo "RELEASE_BOM=$RELEASE_BOM" >> "$GITHUB_ENV"
 
       - name: Install build dependencies
         run: |
@@ -129,6 +146,7 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             dist/*.whl \
             dist/*.tar.gz \
+            "$RELEASE_BOM#Wilfred $RELEASE_VERSION BOM" \
             --verify-tag \
             --title "Wilfred $GITHUB_REF_NAME" \
             --notes-file "$RELEASE_NOTES"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Wilfred separates a few concepts deliberately:
 - a **domain** groups related knowledge and behaviour;
 - a **goal** describes the outcome the user wants.
 
-Plugins can package the tools and domain behaviour needed to add new
-capabilities without pushing that knowledge into the conversational layer.
+Plugins can package tools and domain behaviour without pushing that knowledge
+into the conversational layer. Butler Core provides the provider-neutral
+contracts for domains, capabilities and contributions; Wilfred owns discovery,
+loading, aggregation, introspection and runtime composition.
 
 The official Home Assistant plugin, for example, connects Wilfred to the
 physical smart-home layer while Home Assistant remains responsible for devices,
@@ -50,7 +52,7 @@ The point is not to create one automation for every possible request. Each
 domain contributes the knowledge it owns.
 
 These examples do not mean that every domain already exists publicly in
-Wilfred 0.2.0.
+Wilfred 0.2.2.
 
 ## Capability maturity
 
@@ -60,8 +62,8 @@ Wilfred uses three maturity labels for public features and capability examples.
 
 Public, documented and usable today.
 
-Wilfred 0.2.0 ships the runtime foundation and official Home Assistant bridge
-described in [Current Public Alpha](#current-public-alpha).
+Wilfred 0.2.2 ships the capability-first Public Alpha foundation described in
+[Current Public Alpha](#current-public-alpha).
 
 ### 🧪 In testing
 
@@ -86,6 +88,10 @@ and examples.
 
 Known requests can be resolved deterministically first. More open-ended goals
 can optionally fall back to a planner.
+
+Capabilities may own their deterministic resolvers. Plugins may also declare
+deterministic verification expectations that Wilfred executes through the
+normal runtime path.
 
 Planning does not bypass execution policy. Permissions, confirmation and
 validation remain runtime responsibilities.
@@ -160,6 +166,10 @@ python -m pip install -e ".[dev]"
 See [`docs/installation.md`](docs/installation.md) and
 [`docs/onboarding.md`](docs/onboarding.md) for the complete native setup.
 
+See [`docs/capability-domain-contracts.md`](docs/capability-domain-contracts.md)
+and [`docs/plugin-authoring.md`](docs/plugin-authoring.md) for capability-first
+plugin authoring and ownership boundaries.
+
 See [`docs/execution-engine.md`](docs/execution-engine.md) for validation,
 permissions, confirmations, timeouts and structured execution results.
 
@@ -168,15 +178,20 @@ endpoints and security boundary.
 
 ## Current Public Alpha
 
-Wilfred `0.2.1` is the current Public Alpha.
+Wilfred `0.2.2` is the current Public Alpha.
 
 It currently provides:
 
 - a standalone public runtime;
 - autonomous identity and configuration;
-- public tool and plugin contracts;
-- shared tool, registry, execution and deterministic resolution contracts from Butler Core 0.1.4;
+- public tool and plugin compatibility surfaces;
+- Butler Core 0.2.0 as the immutable provider-neutral contract baseline;
+- Core-owned domain, capability, plugin/contribution and goal-expectation contracts;
 - deterministic plugin loading;
+- a Wilfred-owned capability registry and runtime introspection;
+- capability-owned deterministic resolvers before planner fallback;
+- CLI and HTTP domain/capability discovery;
+- plugin-declared deterministic verification contributions;
 - an Execution Engine facade backed by Butler Core;
 - provider-neutral planned execution backed by Butler Core;
 - a public goal-oriented `WilfredRuntime` composition API;
@@ -185,8 +200,11 @@ It currently provides:
 - an optional OpenAI BYOK planner provider;
 - provider-agnostic READ-ACTION-VERIFY workflows;
 - clean-room wheel verification as a standalone distribution;
+- public CI coverage reporting;
+- the dependency-free `demo.echo` reference capability plugin;
 - the official public Home Assistant plugin;
-- the reference Docker distribution.
+- the reference Docker distribution;
+- a version-specific immutable BOM for every public release checkpoint.
 
 The Public Alpha does not yet provide generic multi-tool planning chains,
 background workers, schedulers or retry infrastructure.
@@ -195,9 +213,8 @@ Its runtime, APIs and plugin contracts may continue to evolve, and
 compatibility guarantees remain more limited than they will be for a stable
 release.
 
-See [`docs/execution-engine.md`](docs/execution-engine.md) for execution
-semantics and [`docs/http-api.md`](docs/http-api.md) for the optional HTTP
-transport.
+See [`docs/releases/0.2.2.md`](docs/releases/0.2.2.md) for the release scope and
+`distribution/releases/0.2.2.toml` for the exact dependency baseline.
 
 If Wilfred is useful to you and you would like to support its continued
 development, you can [support Wilfred on Ko-fi](https://ko-fi.com/butlerwilfred).

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
       args:
         WILFRED_HOME_ASSISTANT_REF: "${WILFRED_HOME_ASSISTANT_REF:-60882a1efba3c3a248047ff69c8ca83352263da7}"
 
-    image: "${WILFRED_IMAGE:-wilfred:0.2.0-dev}"
+    image: "${WILFRED_IMAGE:-wilfred:0.2.2}"
 
     init: true
     restart: unless-stopped

--- a/distribution/bom.toml
+++ b/distribution/bom.toml
@@ -1,16 +1,24 @@
-schema_version = 1
+schema_version = 2
 distribution = "wilfred-public-alpha"
-channel = "0.2.0-dev"
+release = "0.2.2"
+source_tag = "v0.2.2"
 
 [components.butler_core]
 package = "butler-core"
-version = "0.1.4"
+version = "0.2.0"
+artifact = "butler_core-0.2.0-py3-none-any.whl"
+url = "https://github.com/keriol/butler-core/releases/download/v0.2.0/butler_core-0.2.0-py3-none-any.whl"
+sha256 = "40e18d5ef5792c9c5dad807287ae6717e6a0ba0833751503c2ab06c9c2405736"
 
 [components.wilfred]
 package = "wilfred-butler"
-version = "0.2.1"
+version = "0.2.2"
 
 [components.home_assistant]
 package = "wilfred-home-assistant"
 version = "0.1.0.dev0"
 git_ref = "60882a1efba3c3a248047ff69c8ca83352263da7"
+
+[release_scope]
+base_tag = "v0.2.1"
+issues = ["WILF-048", "WILF-053", "WILF-054", "WILF-055", "WILF-056", "WILF-057", "WILF-059", "WILF-062", "WILF-063", "WILF-064"]

--- a/distribution/releases/0.2.0.toml
+++ b/distribution/releases/0.2.0.toml
@@ -1,0 +1,16 @@
+schema_version = 1
+distribution = "wilfred-public-alpha"
+channel = "0.2.0-dev"
+
+[components.butler_core]
+package = "butler-core"
+version = "0.1.3"
+
+[components.wilfred]
+package = "wilfred-butler"
+version = "0.2.0"
+
+[components.home_assistant]
+package = "wilfred-home-assistant"
+version = "0.1.0.dev0"
+git_ref = "60882a1efba3c3a248047ff69c8ca83352263da7"

--- a/distribution/releases/0.2.1.toml
+++ b/distribution/releases/0.2.1.toml
@@ -1,0 +1,16 @@
+schema_version = 1
+distribution = "wilfred-public-alpha"
+channel = "0.2.0-dev"
+
+[components.butler_core]
+package = "butler-core"
+version = "0.1.4"
+
+[components.wilfred]
+package = "wilfred-butler"
+version = "0.2.1"
+
+[components.home_assistant]
+package = "wilfred-home-assistant"
+version = "0.1.0.dev0"
+git_ref = "60882a1efba3c3a248047ff69c8ca83352263da7"

--- a/distribution/releases/0.2.2.toml
+++ b/distribution/releases/0.2.2.toml
@@ -1,0 +1,24 @@
+schema_version = 2
+distribution = "wilfred-public-alpha"
+release = "0.2.2"
+source_tag = "v0.2.2"
+
+[components.butler_core]
+package = "butler-core"
+version = "0.2.0"
+artifact = "butler_core-0.2.0-py3-none-any.whl"
+url = "https://github.com/keriol/butler-core/releases/download/v0.2.0/butler_core-0.2.0-py3-none-any.whl"
+sha256 = "40e18d5ef5792c9c5dad807287ae6717e6a0ba0833751503c2ab06c9c2405736"
+
+[components.wilfred]
+package = "wilfred-butler"
+version = "0.2.2"
+
+[components.home_assistant]
+package = "wilfred-home-assistant"
+version = "0.1.0.dev0"
+git_ref = "60882a1efba3c3a248047ff69c8ca83352263da7"
+
+[release_scope]
+base_tag = "v0.2.1"
+issues = ["WILF-048", "WILF-053", "WILF-054", "WILF-055", "WILF-056", "WILF-057", "WILF-059", "WILF-062", "WILF-063", "WILF-064"]

--- a/docs/ai-developer-model.md
+++ b/docs/ai-developer-model.md
@@ -19,8 +19,8 @@ Use sources in this order for the kind of information they own:
   public software and its architectural contracts.
 - **GitHub Issues** describe active work, task status, priorities,
   dependencies, and planned changes.
-- **GitHub Releases and versioned release notes** describe published
-  checkpoints and release artifacts.
+- **GitHub Releases, versioned release notes, and per-release BOMs** describe
+  published checkpoints, dependency baselines, and release artifacts.
 
 Do not infer current task state from this file.
 
@@ -29,16 +29,20 @@ feature is already implemented.
 
 ## Current public baseline
 
-Wilfred `0.2.1` is the current Public Alpha.
+Wilfred `0.2.2` is the current Public Alpha.
 
 The current runtime includes:
 
 - a standalone Python runtime and configuration model;
-- public tool and plugin contracts;
-- Butler Core `0.1.4` as the provider-neutral execution foundation;
+- public tool and plugin compatibility surfaces;
+- Butler Core `0.2.0` as the provider-neutral contract and execution foundation;
+- Core-owned domain, capability, plugin/contribution and goal-expectation declarations;
 - deterministic plugin loading;
+- a Wilfred-owned semantic capability registry and runtime introspection;
+- capability-owned deterministic request resolution before optional planner fallback;
+- CLI and optional HTTP capability/domain discovery;
+- plugin-declared deterministic verification contributions and a Wilfred verification harness;
 - the shared tool registry and Execution Engine contracts;
-- deterministic request resolution before planner fallback;
 - provider-neutral planned execution;
 - `WilfredRuntime` goal execution;
 - a goal-oriented CLI;
@@ -50,7 +54,8 @@ The current runtime includes:
 - reusable pending-action lifecycle support;
 - provider-latency acknowledgement support;
 - standalone wheel and container distribution;
-- the official public Home Assistant plugin as an external integration.
+- the official public Home Assistant plugin as an external integration;
+- a version-specific release BOM for each public checkpoint.
 
 When documentation and runtime code disagree, inspect current tests and code
 before changing the model.
@@ -65,7 +70,13 @@ The public dependency direction is:
 
 Butler Core owns reusable provider-neutral execution foundations and contracts.
 
-Wilfred consumes those contracts rather than duplicating them.
+Wilfred consumes those contracts rather than duplicating them. In 0.2.2 this
+includes the public domain, capability, plugin/contribution and goal-expectation
+value contracts as exact Core classes.
+
+Core does not own Wilfred plugin discovery/loading, capability aggregation,
+runtime composition, executable verification, transports or provider-specific
+behavior.
 
 Do not move service-specific behavior, presentation behavior, or application
 domain knowledge into Butler Core.
@@ -76,11 +87,14 @@ Wilfred owns public Butler runtime composition.
 
 Its responsibilities include:
 
-- loading plugins;
+- discovering and loading plugins;
 - composing registered tools;
-- resolving known requests deterministically;
+- aggregating domain and capability declarations;
+- exposing deterministic semantic introspection;
+- composing capability-owned deterministic resolvers;
 - falling back to planning when appropriate;
 - applying execution policy;
+- executing plugin-declared verification expectations through the normal runtime path;
 - coordinating goals and workflows;
 - exposing public CLI and HTTP transports.
 
@@ -89,10 +103,13 @@ Transport layers do not become alternate orchestration cores.
 ### Plugins
 
 Plugins connect external integrations to the Wilfred runtime and register
-public executable behavior through Wilfred's plugin and tool contracts.
+public executable behavior through shared Core declarations and Wilfred runtime
+loading surfaces.
 
-Plugin-specific knowledge stays with the plugin rather than entering generic
-conversation or execution infrastructure.
+A plugin may declare domains, capabilities, capability-owned resolvers, tools
+and deterministic verification expectations. Plugin-specific knowledge stays
+with the plugin rather than entering generic conversation or execution
+infrastructure.
 
 ## Resolution and execution
 
@@ -113,6 +130,34 @@ Where success can be observed, use:
 `READ → ACTION → READ → VERIFY`
 
 Dispatch alone is not proof that the requested external state was reached.
+
+## Verification contributions
+
+Plugins may declare immutable deterministic goal expectations beside their
+runtime contributions.
+
+Declarations do not execute tests at import time. Wilfred owns the executable
+verification harness, which runs expectations through `WilfredRuntime` and the
+normal resolution/execution path.
+
+Frontend-specific regression concepts remain owned by the frontend that needs
+them and do not become generic Butler Core concepts merely because the shared
+verification pattern exists.
+
+## Release and BOM discipline
+
+Every released Wilfred version has its own immutable dependency baseline.
+
+`distribution/bom.toml` represents the current release baseline and must match
+the version-specific snapshot under `distribution/releases/<version>.toml` at
+release time.
+
+The release workflow publishes that version-specific BOM beside the wheel and
+source distribution.
+
+If a release-contract dependency changes, Wilfred must publish a new semantic
+version rather than silently changing what an existing `x.y.z` means. A
+compatible dependency-baseline change requires at least a patch bump.
 
 ## AI provider boundary
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,11 +32,37 @@ public distribution works without another butler repository.
 
 Wilfred `0.2.0` established the Public Alpha baseline.
 
-The current release baseline is `0.2.1`.
+The current release baseline is `0.2.2`.
 
 Development versions are working lines, not release promises. A new public
 version is opened or released only when accumulated coherent value justifies
 another public checkpoint.
+
+A change to a release-contract dependency requires a new Wilfred semantic
+version. When public compatibility is preserved, that means at least a patch
+bump. A released `x.y.z` must never silently acquire a different dependency
+baseline.
+
+## Release BOM discipline
+
+`distribution/bom.toml` describes the dependency baseline of the current
+release checkpoint.
+
+Every stable release also owns an immutable snapshot at:
+
+`distribution/releases/<version>.toml`
+
+At release time the current BOM and versioned snapshot must be byte-identical.
+The release workflow validates the snapshot against the package version and tag
+and publishes it as a GitHub Release asset beside the wheel and source
+distribution.
+
+The BOM records exact release-contract dependencies. For Wilfred 0.2.2 this
+includes the immutable Butler Core 0.2.0 wheel and SHA256 plus the exact Home
+Assistant plugin commit embedded by the reference Docker distribution.
+
+Historical BOM snapshots are retained rather than rewritten when a later
+release changes dependencies.
 
 ## Native capabilities
 
@@ -68,17 +94,16 @@ standalone bootstrap behavior.
 ### Automated releases
 
 Stable Wilfred releases are published from immutable semantic-version
-tags such as `v0.1.7`.
+tags such as `v0.2.2`.
 
 The release workflow verifies that the tag and package version match,
-that the tagged commit belongs to `main`, and that the public test
-suite passes. It then builds wheel and source distributions, verifies
-the wheel in a clean virtual environment, checks package dependencies
-and CLI entry points, and finally publishes the artifacts as a GitHub
-Release.
+that the tagged commit belongs to `main`, that the version-specific BOM matches
+the current distribution BOM, and that the public test suite passes. It then
+builds wheel and source distributions, verifies the wheel in a clean virtual
+environment, checks package dependencies and CLI entry points, and finally
+publishes the artifacts plus the release BOM as a GitHub Release.
 
-Development versions such as `0.1.7.dev0` therefore cannot be
-published using a stable `v0.1.7` tag.
+Development versions therefore cannot be published using a stable release tag.
 
 ### Versioned release notes
 

--- a/docs/execution-engine.md
+++ b/docs/execution-engine.md
@@ -88,9 +88,10 @@ Provider-agnostic READ-ACTION-VERIFY workflows build on it without
 redefining Execution Engine `success` as proof of external state change.
 See [Verified workflows](verified-workflows.md).
 
-Native capabilities, verified workflows and local workflow persistence are
-available. Goal APIs, the official Home Assistant plugin and the Wilfred
-`0.2.1` Public Alpha are part of the current public surface.
+Native capabilities, capability-owned deterministic resolvers, plugin
+verification contributions, verified workflows and local workflow persistence
+are available. Goal APIs, the official Home Assistant plugin and the Wilfred
+`0.2.2` Public Alpha are part of the current public surface.
 
 Additional native capabilities and further Public Alpha hardening remain
 under active development.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -142,10 +142,12 @@ See [HTTP API](http-api.md).
 
 ## 7. Current public-alpha boundary
 
-Wilfred `0.2.1` is the current Public Alpha.
+Wilfred `0.2.2` is the current Public Alpha.
 
-The Public Alpha includes the standalone runtime, the official Home Assistant
-plugin integration and the reference Docker distribution.
+The Public Alpha includes the standalone runtime, first-class domain/capability
+composition, deterministic capability-owned resolvers, plugin verification
+contributions, the official Home Assistant plugin integration and the reference
+Docker distribution.
 
 The following remain outside the completed Public Alpha scope:
 - a complete collection of native Butler capabilities;

--- a/docs/releases/0.2.2.md
+++ b/docs/releases/0.2.2.md
@@ -1,0 +1,86 @@
+# Wilfred 0.2.2
+
+Wilfred 0.2.2 is the capability-first Public Alpha checkpoint.
+
+It promotes domains and capabilities from architectural vocabulary into an executable, inspectable plugin model, adds plugin-owned deterministic resolvers and verification contributions, and adopts Butler Core 0.2.0 as the immutable provider-neutral contract baseline.
+
+## Highlights
+
+- First-class domain and capability declarations for public plugins.
+- Deterministic `CapabilityRegistry` with runtime introspection.
+- Capability-owned deterministic resolvers before planner fallback.
+- CLI and HTTP capability/domain discovery with sanitized public metadata.
+- Dependency-free `demo.echo` reference capability plugin and authoring guide.
+- Plugin-declared deterministic verification expectations and shared verification harness.
+- Exact re-export of Core-owned `DomainDefinition`, `CapabilityDefinition`, `PluginDefinition` and `GoalExpectation` contracts.
+- Butler Core 0.2.0 pinned to the published wheel with SHA256 integrity evidence.
+- Public CI coverage reporting.
+- Public AI developer model for repository-safe coding-assistant context.
+- Per-release immutable BOM snapshots, starting with preserved 0.2.0/0.2.1 history and the 0.2.2 release BOM.
+
+## Butler Core 0.2.0 adoption
+
+Wilfred 0.2.2 consumes Butler Core 0.2.0 through the published wheel:
+
+`butler_core-0.2.0-py3-none-any.whl`
+
+SHA256:
+
+`40e18d5ef5792c9c5dad807287ae6717e6a0ba0833751503c2ab06c9c2405736`
+
+Core owns the reusable provider-neutral domain, capability, plugin/contribution and goal-expectation declarations. Wilfred preserves its existing public import surfaces as compatibility facades while continuing to own plugin discovery/loading, capability aggregation, runtime composition, introspection and executable verification.
+
+Core does not become the Wilfred plugin runtime.
+
+## Capability-first runtime
+
+Plugins can declare the domains and capabilities they own. Capabilities can own deterministic resolvers, and Wilfred composes those resolvers deterministically before optional planner fallback.
+
+The semantic `CapabilityRegistry` remains separate from the executable `ToolRegistry`. Ownership conflicts are rejected explicitly, while tool-only plugins retain their compatibility path.
+
+Runtime capability and domain information is available through public CLI and optional HTTP discovery surfaces without exposing credentials or executable handlers.
+
+## Reference plugin and verification
+
+The dependency-free `demo.echo` plugin demonstrates the full public path:
+
+`provider -> plugin -> domain -> capability -> resolver -> tool`
+
+It also declares a deterministic verification expectation. Wilfred's verification harness executes those expectations through the normal runtime path, so verification does not bypass resolution or execution policy.
+
+## Release BOM
+
+Wilfred releases now retain a version-specific BOM under `distribution/releases/<version>.toml`.
+
+The 0.2.2 BOM records:
+
+- Wilfred 0.2.2;
+- Butler Core 0.2.0 and its immutable wheel digest;
+- the Home Assistant distribution component at version `0.1.0.dev0` and commit `60882a1efba3c3a248047ff69c8ca83352263da7`;
+- the base release tag and included task IDs.
+
+The release workflow requires the current BOM to match the versioned snapshot and publishes that snapshot as a GitHub Release asset beside the wheel and source distribution.
+
+A released Wilfred version therefore cannot silently acquire a different dependency baseline. A release-contract dependency change requires a new Wilfred version and a new BOM.
+
+## Included GitHub work
+
+The explicit `v0.2.1..v0.2.2` release delta includes:
+
+- #90, public AI developer model;
+- #44 / WILF-048, public CI coverage reporting;
+- #35 / WILF-053, capability and domain contracts;
+- #36 / WILF-054, plugin-declared capabilities and domains;
+- #37 / WILF-055, capability registry and runtime introspection;
+- #38 / WILF-056, capability-owned deterministic resolvers;
+- #39 / WILF-057, CLI and HTTP capability discovery;
+- #41 / WILF-059, reference capability plugin and authoring guide;
+- #101 / WILF-062, plugin-declared verification contributions;
+- #103 / WILF-063, Butler Core 0.2.0 contribution-contract adoption;
+- #104 / WILF-064, Wilfred 0.2.2 release and BOM checkpoint.
+
+## Public Alpha
+
+Wilfred 0.2.2 remains a Public Alpha. The capability-first public surface is now substantially more explicit and reusable, but stable-release compatibility guarantees are not yet implied.
+
+Wilfred 0.3.0 remains a separate future checkpoint with its own release gates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.2.1"
+version = "0.2.2"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_ai_developer_model.py
+++ b/tests/test_ai_developer_model.py
@@ -14,8 +14,8 @@ class PublicAIDeveloperModelTests(unittest.TestCase):
         text = MODEL.read_text(encoding="utf-8")
 
         for term in (
-            "Wilfred `0.2.1`",
-            "Butler Core `0.1.4`",
+            "Wilfred `0.2.2`",
+            "Butler Core `0.2.0`",
             "GitHub Issues",
             "deterministic request resolution",
             "optional planner fallback",
@@ -23,6 +23,7 @@ class PublicAIDeveloperModelTests(unittest.TestCase):
             "WilfredRuntime",
             "READ → ACTION → READ → VERIFY",
             "official public Home Assistant plugin",
+            "version-specific release BOM",
         ):
             self.assertIn(term, text)
 

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -34,6 +34,7 @@ def test_compose_keeps_runtime_hardened() -> None:
         "wilfred_home_assistant.bootstrap:"
         "create_plugin_from_environment"
     ) in compose
+    assert "wilfred:0.2.2" in compose
 
 
 def test_reference_binding_is_loopback_only() -> None:
@@ -46,19 +47,30 @@ def test_reference_binding_is_loopback_only() -> None:
 
 
 def test_distribution_bom_matches_release_baseline() -> None:
-    with (
-        ROOT / "distribution" / "bom.toml"
-    ).open("rb") as stream:
+    current_path = ROOT / "distribution" / "bom.toml"
+    snapshot_path = (
+        ROOT / "distribution" / "releases" / "0.2.2.toml"
+    )
+
+    assert current_path.read_bytes() == snapshot_path.read_bytes()
+
+    with current_path.open("rb") as stream:
         bom = tomllib.load(stream)
 
-    assert bom["schema_version"] == 1
+    assert bom["schema_version"] == 2
+    assert bom["release"] == "0.2.2"
+    assert bom["source_tag"] == "v0.2.2"
     assert (
         bom["components"]["butler_core"]["version"]
-        == "0.1.4"
+        == "0.2.0"
+    )
+    assert (
+        bom["components"]["butler_core"]["sha256"]
+        == "40e18d5ef5792c9c5dad807287ae6717e6a0ba0833751503c2ab06c9c2405736"
     )
     assert (
         bom["components"]["wilfred"]["version"]
-        == "0.2.1"
+        == "0.2.2"
     )
     assert (
         bom["components"]["home_assistant"]["version"]
@@ -72,6 +84,24 @@ def test_distribution_bom_matches_release_baseline() -> None:
     assert len(plugin_ref) == 40
     int(plugin_ref, 16)
 
+    assert bom["release_scope"]["base_tag"] == "v0.2.1"
+    assert "WILF-063" in bom["release_scope"]["issues"]
+    assert "WILF-064" in bom["release_scope"]["issues"]
+
+
+def test_previous_release_bom_snapshots_are_preserved() -> None:
+    releases = ROOT / "distribution" / "releases"
+
+    with (releases / "0.2.0.toml").open("rb") as stream:
+        bom_020 = tomllib.load(stream)
+    with (releases / "0.2.1.toml").open("rb") as stream:
+        bom_021 = tomllib.load(stream)
+
+    assert bom_020["components"]["wilfred"]["version"] == "0.2.0"
+    assert bom_020["components"]["butler_core"]["version"] == "0.1.3"
+    assert bom_021["components"]["wilfred"]["version"] == "0.2.1"
+    assert bom_021["components"]["butler_core"]["version"] == "0.1.4"
+
 
 def test_examples_contain_no_credentials() -> None:
     env_example = read(
@@ -80,6 +110,7 @@ def test_examples_contain_no_credentials() -> None:
 
     assert "WILFRED_OPENAI_API_KEY=\n" in env_example
     assert "WILFRED_HOME_ASSISTANT_TOKEN=\n" in env_example
+
 
 def test_runtime_checkout_is_reusable() -> None:
     checkout = ROOT / "distribution" / "verify_runtime.py"
@@ -106,4 +137,3 @@ def test_container_ci_verifies_registry_pull() -> None:
     assert "docker image rm" in workflow
     assert "docker pull" in workflow
     assert "verify_runtime.py" in workflow
-

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -50,7 +50,7 @@ class WilfredDocumentationTests(unittest.TestCase):
             len(set(h2_headings)),
         )
         self.assertIn(
-            "Wilfred `0.2.1` is the current Public Alpha",
+            "Wilfred `0.2.2` is the current Public Alpha",
             readme,
         )
         self.assertIn(
@@ -86,7 +86,7 @@ class WilfredDocumentationTests(unittest.TestCase):
             "demo.echo",
             "WILFRED_OPENAI_API_KEY",
             "127.0.0.1:8000",
-            "0.2.1",
+            "0.2.2",
             "official Home Assistant",
         ):
             self.assertIn(term, guide)
@@ -196,7 +196,7 @@ class WilfredDocumentationTests(unittest.TestCase):
         normalized = " ".join(guide.split())
 
         self.assertIn(
-            "Wilfred `0.2.1` Public Alpha",
+            "Wilfred `0.2.2` Public Alpha",
             normalized,
         )
         self.assertIn(
@@ -219,8 +219,6 @@ class WilfredDocumentationTests(unittest.TestCase):
             'tool_name="example_tool"',
             guide,
         )
-
-
 
     def test_verified_workflow_guide_documents_contract(self) -> None:
         guide = (
@@ -247,8 +245,6 @@ class WilfredDocumentationTests(unittest.TestCase):
             "Automatic ACTION retries are deliberately outside",
             normalized,
         )
-
-
 
     def test_persistence_guide_documents_contract(self) -> None:
         guide = (


### PR DESCRIPTION
## Summary

Prepare Wilfred 0.2.2 as the capability-first Public Alpha checkpoint and establish the per-release immutable BOM discipline required by WILF-060.

## Release scope

The explicit `v0.2.1..main` delta contains the capability-first public model accumulated since 0.2.1, including WILF-048, WILF-053, WILF-054, WILF-055, WILF-056, WILF-057, WILF-059, WILF-062 and WILF-063 plus the public AI developer model.

## Changes

- set package version to 0.2.2;
- preserve historical BOM snapshots for 0.2.0 and 0.2.1 from their released tags;
- add the version-specific 0.2.2 BOM with exact Butler Core 0.2.0 wheel/digest and Home Assistant plugin commit;
- require `distribution/bom.toml` to match `distribution/releases/<version>.toml` at release time;
- publish the version-specific BOM as a GitHub Release asset beside wheel and sdist;
- align the reference Docker image tag with 0.2.2;
- publish versioned 0.2.2 release notes;
- update README, developer model and development guidance;
- add regression tests for historical and current BOM snapshots.

## Dependency baseline

Butler Core 0.2.0 wheel SHA256:
`40e18d5ef5792c9c5dad807287ae6717e6a0ba0833751503c2ab06c9c2405736`

Reference Docker Home Assistant plugin component:
`wilfred-home-assistant 0.1.0.dev0 @ 60882a1efba3c3a248047ff69c8ca83352263da7`

## Release discipline

No tag or release is created by this PR. After merge and post-merge verification, `v0.2.2` will be created from verified `main`; the tag-triggered release workflow must then publish wheel, sdist and the exact 0.2.2 BOM snapshot.

Closes #104 after release publication and observable verification are complete.