### PR TITLE
DOC-004: align Wilfred docs with Home Assistant Plugin boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,18 @@ into the conversational layer. Butler Core provides the provider-neutral
 contracts for domains, capabilities and contributions; Wilfred owns discovery,
 loading, aggregation, introspection and runtime composition.
 
-The official Home Assistant plugin, for example, connects Wilfred to the
-physical smart-home layer while Home Assistant remains responsible for devices,
-integrations and physical orchestration.
+The public [Home Assistant Plugin](https://github.com/keriol/home-assistant-plugin)
+is the first real smart-home integration built around this model. It began as a
+concrete proving example for Wilfred and is now evolving into a reusable Butler
+plugin in its own right. Home Assistant remains responsible for devices,
+integrations and physical orchestration; the plugin owns reusable Home
+Assistant integration behaviour; Wilfred remains one consumer of that plugin.
+
+That boundary is deliberate. Home Assistant is not baked into Butler Core and
+is not the only smart-home manager the architecture can support. A future
+integration for another automation platform can be implemented as another
+plugin following the same provider-neutral Butler contracts rather than adding
+platform-specific logic to Wilfred itself.
 
 ## What could you build?
 
@@ -71,7 +80,8 @@ Implemented or actively consolidated in a private real-world Butler deployment,
 but not yet published as reusable Wilfred capabilities.
 
 Current validation areas include richer media behaviour, appliances and
-laundry, and proactive communication.
+laundry, proactive communication and reusable plugin composition across Butler
+runtimes.
 
 **In testing is not a release promise.**
 
@@ -110,7 +120,8 @@ READ → ACTION → READ → VERIFY workflows.
 ### Docker Compose
 
 Docker Compose is the quickest way to run the Wilfred Public Alpha
-with the official Home Assistant plugin.
+with the Home Assistant integration currently included in the reference
+distribution.
 
 ```bash
 git clone https://github.com/keriol/butler-wilfred.git
@@ -202,9 +213,15 @@ It currently provides:
 - clean-room wheel verification as a standalone distribution;
 - public CI coverage reporting;
 - the dependency-free `demo.echo` reference capability plugin;
-- the official public Home Assistant plugin;
+- the public Home Assistant integration currently consumed by the reference distribution;
 - the reference Docker distribution;
 - a version-specific immutable BOM for every public release checkpoint.
+
+The canonical Home Assistant repository is now
+[`keriol/home-assistant-plugin`](https://github.com/keriol/home-assistant-plugin).
+Its ongoing HAP-004 work is moving the plugin from the original Wilfred-coupled
+implementation to a consumer-neutral Butler Core boundary. That direction is
+not retroactively claimed as part of Wilfred 0.2.2.
 
 The Public Alpha does not yet provide generic multi-tool planning chains,
 background workers, schedulers or retry infrastructure.
@@ -230,6 +247,11 @@ any private consumer deployment.
 
 Consumer-specific integrations, infrastructure details, credentials and
 operational configuration belong in separate repositories.
+
+Reusable integrations may also live in independent plugin repositories. The
+Home Assistant Plugin is the first concrete example: a plugin can evolve and be
+consumed independently of Wilfred while still using the same Butler Core
+contracts.
 
 ## Provider-agnostic output
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -3,13 +3,20 @@
 Wilfred can run as a standalone container while integrations remain external
 plugin packages.
 
-The official Public Alpha composition currently contains:
+The current Public Alpha reference composition contains:
 
 - Wilfred standalone runtime;
 - Butler Core through Wilfred's package dependency;
-- the official Home Assistant plugin;
+- the Home Assistant integration from the public Home Assistant Plugin project;
 - the optional Wilfred HTTP transport;
 - the optional OpenAI planner provider.
+
+The canonical Home Assistant integration repository is
+[`keriol/home-assistant-plugin`](https://github.com/keriol/home-assistant-plugin).
+The plugin was originally composed as a Wilfred-specific dependency and is now
+being migrated under HAP-004 toward a consumer-neutral Butler Core boundary.
+Historical Wilfred release BOMs remain authoritative for the exact dependency
+that each released image actually contained.
 
 Home Assistant itself is not installed inside the Wilfred container.
 
@@ -75,12 +82,14 @@ not require mounting the host Docker socket into the Wilfred runtime.
 
 ## Compatibility
 
-`distribution/bom.toml` is the compatibility snapshot for this development
-distribution.
+`distribution/bom.toml` is the compatibility snapshot for the current
+development distribution. Version-specific files under
+`distribution/releases/` are immutable release evidence and may legitimately
+retain the historical repository/package identity used by that release.
 
-The Home Assistant plugin is pinned to an immutable public Git revision during
-the 0.2.0 development cycle. Stable package and image references are finalized
-as part of the 0.2.0 release choreography.
+Do not infer the active HAP-004 consumer-neutral migration from an older Wilfred
+BOM. A future Wilfred release adopts a new HAP dependency baseline only through
+explicit release scope and evidence.
 
 ## Container artifact checkout
 

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -83,6 +83,11 @@ Before configuring an AI provider, follow the deterministic plugin example in
 That verifies plugin discovery, registration and Execution Engine behaviour
 independently from provider credentials or model behaviour.
 
+The public [Home Assistant Plugin](https://github.com/keriol/home-assistant-plugin)
+is the real smart-home integration used to exercise the same model against an
+external automation platform. It is maintained as its own HAP project rather
+than as a Home Assistant subsystem inside Wilfred.
+
 ## 5. Optional OpenAI BYOK planning
 
 OpenAI support is optional.
@@ -146,8 +151,13 @@ Wilfred `0.2.2` is the current Public Alpha.
 
 The Public Alpha includes the standalone runtime, first-class domain/capability
 composition, deterministic capability-owned resolvers, plugin verification
-contributions, the official Home Assistant plugin integration and the reference
-Docker distribution.
+contributions, the Home Assistant integration used by the reference
+distribution and the reference Docker distribution.
+
+The canonical integration repository is
+[`keriol/home-assistant-plugin`](https://github.com/keriol/home-assistant-plugin).
+Its consumer-neutral HAP migration is active development and is not
+retroactively part of the Wilfred 0.2.2 release contract.
 
 The following remain outside the completed Public Alpha scope:
 - a complete collection of native Butler capabilities;

--- a/docs/plugin-authoring.md
+++ b/docs/plugin-authoring.md
@@ -6,12 +6,19 @@ The built-in `demo.echo` plugin is the reference implementation. It is intention
 
 `provider → plugin → domain → capability → resolver → tool`
 
+The public [Home Assistant Plugin](https://github.com/keriol/home-assistant-plugin)
+is the first real smart-home integration built around this model. It began as a
+concrete Wilfred proving example and is now evolving toward a consumer-neutral
+Butler plugin that can be loaded by independent sibling runtimes. That evolution
+is useful evidence that the plugin contract should describe the integration,
+not bind it permanently to one host runtime.
+
 ## Ownership model
 
 Each layer has one job.
 
 - **Provider / integration** connects to or adapts an external service. In the reference plugin, `EchoProvider` is the provider boundary and `LocalEchoProvider` is the dependency-free example implementation.
-- **Plugin** packages everything that belongs together and declares what it contributes to Wilfred.
+- **Plugin** packages everything that belongs together and declares what it contributes to a Butler runtime.
 - **Domain** owns related knowledge and behavior. The reference plugin declares the `demo` domain.
 - **Capability** names something the Butler knows how to do inside that domain. The reference plugin declares `demo.echo`.
 - **Resolver** deterministically recognizes goals that the capability can handle and produces a normal tool plan. The reference resolver is `demo.echo.text`.
@@ -179,6 +186,7 @@ Keep these boundaries stable when creating a real plugin:
 7. Declare representative deterministic expectations instead of embedding test-framework execution in plugin import paths.
 8. Keep frontend presentation and provider-specific rendering outside Butler Core.
 9. Do not put secrets, private endpoints or deployment-specific identifiers in public plugin metadata or verification declarations.
+10. Keep the plugin dependent on provider-neutral Butler contracts where possible rather than on one sibling runtime merely because that runtime was its first consumer.
 
 ## Testing a plugin
 
@@ -202,6 +210,24 @@ Replace `LocalEchoProvider` with a provider adapter that owns the actual externa
 
 `external service → provider adapter → plugin package → domain/capability → resolver → typed tool → Execution Engine`
 
-The Home Assistant plugin is a real consumer of the same public model, but it is intentionally not used as the authoring example so the reference remains small, installable and independent of any particular home-automation platform.
+The Home Assistant Plugin is a real consumer of the same public model, but it is intentionally not used as the small authoring example so the reference remains installable and independent of any particular home-automation platform.
+
+The architectural lesson from HAP is broader than Home Assistant. If a user wants to integrate another home-automation manager, the preferred direction is another dedicated plugin:
+
+```text
+Butler runtime
+    |
+    +-> Home Assistant Plugin -> Home Assistant
+    |
+    +-> Platform X Plugin     -> Platform X
+```
+
+Each platform plugin owns its authentication, transport and platform-specific
+operations. Butler Core stays provider-neutral, and the host runtime does not
+need platform-specific device APIs baked into its own code.
+
+HAP is currently being migrated toward that fully consumer-neutral boundary.
+Do not infer completed dependency changes from this design note; use the HAP
+repository and GitHub Issues for current implementation evidence.
 
 For the detailed semantic contracts and deterministic ordering rules, see [Capability and domain contracts](capability-domain-contracts.md).

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -20,17 +20,26 @@ use, and what the capability model is designed to enable.
 
 ## ✅ Available
 
-These foundations are public in Wilfred 0.2.1.
+These foundations are public in Wilfred 0.2.2.
 
 ### Home Assistant connectivity
 
-The official Home Assistant plugin gives Wilfred access to the physical
-smart-home layer.
+The public [Home Assistant Plugin](https://github.com/keriol/home-assistant-plugin)
+connects the Butler ecosystem to the physical smart-home layer.
 
 Home Assistant remains responsible for devices, integrations and physical
 orchestration.
 
 Wilfred does not try to replace it.
+
+The plugin was originally built as a concrete Wilfred proving example. Its
+current development direction is to become a consumer-neutral Butler plugin
+that can be used by more than one sibling runtime through shared Butler Core
+contracts.
+
+That makes Home Assistant an example of the plugin architecture, not a special
+case inside Wilfred. A future integration for another home-automation manager
+can follow the same model with a separate platform plugin.
 
 ### Deterministic resolution
 
@@ -102,6 +111,15 @@ Proactive communication is also being validated as a separate concern.
 The Butler can decide what needs to be communicated without coupling the
 runtime itself to one particular delivery frontend.
 
+### Reusable plugin composition
+
+The Home Assistant Plugin is also being used as a real proving case for a
+stronger plugin boundary: one plugin artifact, shared Core contracts and
+multiple independent Butler runtimes as consumers.
+
+This direction is under active development and is not retroactively part of
+the Wilfred 0.2.2 release contract.
+
 ### What "In testing" means
 
 In testing is not a release promise.
@@ -120,7 +138,7 @@ it may still require:
 
 These examples illustrate where the capability model can go.
 
-They are not claims about features already shipped in Wilfred 0.2.0.
+They are not claims about features already shipped in Wilfred 0.2.2.
 
 ### Energy-aware appliances
 
@@ -159,6 +177,23 @@ an integration handles the actual sensors and irrigation hardware.
 
 The domain knowledge remains separate from the device transport.
 
+### Another home-automation platform
+
+Home Assistant is not an architectural requirement of Wilfred.
+
+A different automation manager can be integrated through its own plugin that
+implements the shared Butler contracts while keeping platform-specific
+authentication, transport and API behavior in that plugin.
+
+Conceptually:
+
+    Butler runtime
+       ├── Home Assistant Plugin -> Home Assistant
+       └── Another Home Plugin   -> another automation platform
+
+The runtime remains focused on composition and capability execution rather than
+learning every platform API itself.
+
 ### Your domain
 
 Wilfred is not limited to smart-home examples.
@@ -182,7 +217,7 @@ The useful question becomes:
 
 ## Public Alpha boundary
 
-Wilfred 0.2.1 provides the public runtime foundations for this model.
+Wilfred 0.2.2 provides the public runtime foundations for this model.
 
 It does not yet provide a complete catalogue of domain capabilities.
 

--- a/tests/test_documentation.py
+++ b/tests/test_documentation.py
@@ -87,7 +87,7 @@ class WilfredDocumentationTests(unittest.TestCase):
             "WILFRED_OPENAI_API_KEY",
             "127.0.0.1:8000",
             "0.2.2",
-            "official Home Assistant",
+            "Home Assistant Plugin",
         ):
             self.assertIn(term, guide)
 


### PR DESCRIPTION
## Summary

Update live Wilfred documentation for the renamed Home Assistant Plugin and the corrected reusable-plugin boundary.

- canonical repository is `keriol/home-assistant-plugin`;
- HAP is described as a first real smart-home plugin, not a Wilfred-owned architectural exception;
- plugin authoring docs explain how another home-automation manager can integrate through its own plugin;
- current Public Alpha references are aligned to Wilfred 0.2.2;
- active HAP-004 consumer-neutral migration is clearly separated from the immutable Wilfred 0.2.2 release contract;
- Docker docs explicitly preserve historical BOM/release evidence.

Parent documentation task: `keriol/alfred#191` (DOC-004).

No runtime, package dependency, Dockerfile or BOM change in this PR.