### PR TITLE
WILF-065: consume independent HAP on 0.2.3.dev0

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -34,99 +34,122 @@ jobs:
 
       - name: Build image
         run: |
-          docker build             --build-arg WILFRED_HOME_ASSISTANT_REF=60882a1efba3c3a248047ff69c8ca83352263da7             --tag wilfred:ci             .
+          docker build \
+            --build-arg HAP_REF=d1856791b887c36e54c71fe3e81646f969249885 \
+            --tag wilfred:ci \
+            .
 
       - name: Prepare public test configuration
         run: |
           mkdir -p /tmp/wilfred-container-config
-
-          cp             distribution/home-assistant.example.toml             /tmp/wilfred-container-config/home-assistant.toml
-
-          chmod 755             /tmp/wilfred-container-config
-
-          chmod 644             /tmp/wilfred-container-config/home-assistant.toml
+          cp distribution/home-assistant.example.toml /tmp/wilfred-container-config/home-assistant.toml
+          chmod 755 /tmp/wilfred-container-config
+          chmod 644 /tmp/wilfred-container-config/home-assistant.toml
 
       - name: Start built image
         run: |
-          docker run             --detach             --name wilfred-container-ci             --publish 127.0.0.1:18038:8000             --read-only             --tmpfs /tmp:rw,noexec,nosuid,size=64m             --cap-drop ALL             --security-opt no-new-privileges:true             --volume /tmp/wilfred-container-config:/config:ro             --env WILFRED_OPENAI_API_KEY=test-key             --env WILFRED_PLUGINS=wilfred_home_assistant.bootstrap:create_plugin_from_environment             --env WILFRED_HOME_ASSISTANT_URL=http://ha.example:8123             --env WILFRED_HOME_ASSISTANT_TOKEN=test-token             --env WILFRED_HOME_ASSISTANT_CONFIG=/config/home-assistant.toml             wilfred:ci             api             --host 0.0.0.0             --port 8000             --provider openai             --model test-model
+          docker run \
+            --detach \
+            --name wilfred-container-ci \
+            --publish 127.0.0.1:18038:8000 \
+            --read-only \
+            --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --volume /tmp/wilfred-container-config:/config:ro \
+            --env WILFRED_OPENAI_API_KEY=test-key \
+            --env WILFRED_PLUGINS=wilfred_home_assistant.bootstrap:create_plugin_from_environment \
+            --env WILFRED_HOME_ASSISTANT_URL=http://ha.example:8123 \
+            --env WILFRED_HOME_ASSISTANT_TOKEN=test-token \
+            --env WILFRED_HOME_ASSISTANT_CONFIG=/config/home-assistant.toml \
+            wilfred:ci \
+            api \
+            --host 0.0.0.0 \
+            --port 8000 \
+            --provider openai \
+            --model test-model
 
       - name: Verify built image over HTTP
         run: |
-          python distribution/verify_runtime.py             http://127.0.0.1:18038
-
-          test "$(
-            docker exec wilfred-container-ci id -u
-          )" != "0"
-
-          ! docker inspect             --format '{{json .Mounts}}'             wilfred-container-ci             | grep -Fq '/var/run/docker.sock'
+          python distribution/verify_runtime.py http://127.0.0.1:18038
+          test "$(docker exec wilfred-container-ci id -u)" != "0"
+          ! docker inspect --format '{{json .Mounts}}' wilfred-container-ci | grep -Fq '/var/run/docker.sock'
 
       - name: Stop built image
-        run: |
-          docker rm -f wilfred-container-ci
+        run: docker rm -f wilfred-container-ci
 
       - name: Start temporary registry
         run: |
-          docker run             --detach             --name wilfred-registry-ci             --publish 127.0.0.1:15038:5000             registry:2
+          docker run \
+            --detach \
+            --name wilfred-registry-ci \
+            --publish 127.0.0.1:15038:5000 \
+            registry:2
 
       - name: Push image to temporary registry
         run: |
-          ORIGINAL_ID="$(
-            docker image inspect               wilfred:ci               --format '{{.Id}}'
-          )"
-
-          echo "ORIGINAL_ID=$ORIGINAL_ID"             >> "$GITHUB_ENV"
-
-          docker tag             wilfred:ci             localhost:15038/wilfred:ci
-
-          docker push             localhost:15038/wilfred:ci
+          ORIGINAL_ID="$(docker image inspect wilfred:ci --format '{{.Id}}')"
+          echo "ORIGINAL_ID=$ORIGINAL_ID" >> "$GITHUB_ENV"
+          docker tag wilfred:ci localhost:15038/wilfred:ci
+          docker push localhost:15038/wilfred:ci
 
       - name: Remove local image
         run: |
-          docker image rm             wilfred:ci             localhost:15038/wilfred:ci
-
-          if docker image inspect             localhost:15038/wilfred:ci             >/dev/null 2>&1
-          then
+          docker image rm wilfred:ci localhost:15038/wilfred:ci
+          if docker image inspect localhost:15038/wilfred:ci >/dev/null 2>&1; then
             echo "Image unexpectedly remains locally."
             false
           fi
 
       - name: Pull image from temporary registry
         run: |
-          docker pull             localhost:15038/wilfred:ci
-
-          PULLED_ID="$(
-            docker image inspect               localhost:15038/wilfred:ci               --format '{{.Id}}'
-          )"
-
+          docker pull localhost:15038/wilfred:ci
+          PULLED_ID="$(docker image inspect localhost:15038/wilfred:ci --format '{{.Id}}')"
           echo "Original: $ORIGINAL_ID"
           echo "Pulled:   $PULLED_ID"
-
           test "$PULLED_ID" = "$ORIGINAL_ID"
 
       - name: Start pulled image
         run: |
-          docker run             --detach             --name wilfred-container-pulled-ci             --publish 127.0.0.1:18039:8000             --read-only             --tmpfs /tmp:rw,noexec,nosuid,size=64m             --cap-drop ALL             --security-opt no-new-privileges:true             --volume /tmp/wilfred-container-config:/config:ro             --env WILFRED_OPENAI_API_KEY=test-key             --env WILFRED_PLUGINS=wilfred_home_assistant.bootstrap:create_plugin_from_environment             --env WILFRED_HOME_ASSISTANT_URL=http://ha.example:8123             --env WILFRED_HOME_ASSISTANT_TOKEN=test-token             --env WILFRED_HOME_ASSISTANT_CONFIG=/config/home-assistant.toml             localhost:15038/wilfred:ci             api             --host 0.0.0.0             --port 8000             --provider openai             --model test-model
+          docker run \
+            --detach \
+            --name wilfred-container-pulled-ci \
+            --publish 127.0.0.1:18039:8000 \
+            --read-only \
+            --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+            --cap-drop ALL \
+            --security-opt no-new-privileges:true \
+            --volume /tmp/wilfred-container-config:/config:ro \
+            --env WILFRED_OPENAI_API_KEY=test-key \
+            --env WILFRED_PLUGINS=wilfred_home_assistant.bootstrap:create_plugin_from_environment \
+            --env WILFRED_HOME_ASSISTANT_URL=http://ha.example:8123 \
+            --env WILFRED_HOME_ASSISTANT_TOKEN=test-token \
+            --env WILFRED_HOME_ASSISTANT_CONFIG=/config/home-assistant.toml \
+            localhost:15038/wilfred:ci \
+            api \
+            --host 0.0.0.0 \
+            --port 8000 \
+            --provider openai \
+            --model test-model
 
       - name: Verify pulled image over HTTP
         run: |
-          python distribution/verify_runtime.py             http://127.0.0.1:18039
-
-          test "$(
-            docker exec               wilfred-container-pulled-ci               id -u
-          )" != "0"
-
-          ! docker inspect             --format '{{json .Mounts}}'             wilfred-container-pulled-ci             | grep -Fq '/var/run/docker.sock'
+          python distribution/verify_runtime.py http://127.0.0.1:18039
+          test "$(docker exec wilfred-container-pulled-ci id -u)" != "0"
+          ! docker inspect --format '{{json .Mounts}}' wilfred-container-pulled-ci | grep -Fq '/var/run/docker.sock'
 
       - name: Show logs on failure
         if: failure()
         run: |
-          docker logs             wilfred-container-ci             2>/dev/null || true
-
-          docker logs             wilfred-container-pulled-ci             2>/dev/null || true
-
-          docker logs             wilfred-registry-ci             2>/dev/null || true
+          docker logs wilfred-container-ci 2>/dev/null || true
+          docker logs wilfred-container-pulled-ci 2>/dev/null || true
+          docker logs wilfred-registry-ci 2>/dev/null || true
 
       - name: Cleanup
         if: always()
         run: |
-          docker rm -f             wilfred-container-ci             wilfred-container-pulled-ci             wilfred-registry-ci             2>/dev/null || true
+          docker rm -f \
+            wilfred-container-ci \
+            wilfred-container-pulled-ci \
+            wilfred-registry-ci \
+            2>/dev/null || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.12-slim
 
-ARG WILFRED_HOME_ASSISTANT_REF=60882a1efba3c3a248047ff69c8ca83352263da7
+ARG HAP_REF=d1856791b887c36e54c71fe3e81646f969249885
 
 LABEL org.opencontainers.image.title="Wilfred"
 LABEL org.opencontainers.image.description="Standalone public Wilfred Butler runtime"
@@ -18,7 +18,7 @@ RUN groupadd --system wilfred     && useradd         --system         --gid wilf
 COPY pyproject.toml README.md LICENSE ./
 COPY src ./src
 
-RUN python -m pip install         --no-cache-dir         --upgrade         pip         setuptools         wheel     && python -m pip install         --no-cache-dir         ".[http,openai]"     && python -m pip install         --no-cache-dir         "httpx>=0.28,<1"     && python -m pip install         --no-cache-dir         --no-deps         "wilfred-home-assistant @ https://github.com/keriol/wilfred-home-assistant/archive/${WILFRED_HOME_ASSISTANT_REF}.tar.gz"     && python -m pip check
+RUN python -m pip install         --no-cache-dir         --upgrade         pip         setuptools         wheel     && python -m pip install         --no-cache-dir         ".[http,openai]"     && python -m pip install         --no-cache-dir         "httpx>=0.28,<1"     && python -m pip install         --no-cache-dir         --no-deps         "butler-home-assistant @ https://github.com/keriol/home-assistant-plugin/archive/${HAP_REF}.tar.gz"     && python -m pip check
 
 USER wilfred
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,9 +3,9 @@ services:
     build:
       context: .
       args:
-        WILFRED_HOME_ASSISTANT_REF: "${WILFRED_HOME_ASSISTANT_REF:-60882a1efba3c3a248047ff69c8ca83352263da7}"
+        HAP_REF: "${HAP_REF:-d1856791b887c36e54c71fe3e81646f969249885}"
 
-    image: "${WILFRED_IMAGE:-wilfred:0.2.2}"
+    image: "${WILFRED_IMAGE:-wilfred:0.2.3.dev0}"
 
     init: true
     restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "butler-core @ git+https://github.com/keriol/butler-core.git@827bbac1038b6591f88648e5b69e50ae66834c19",
+    "butler-core @ https://github.com/keriol/butler-core/archive/827bbac1038b6591f88648e5b69e50ae66834c19.tar.gz",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,12 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "wilfred-butler"
-version = "0.2.2"
+version = "0.2.3.dev0"
 description = "Public and extensible Butler runtime"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "butler-core @ https://github.com/keriol/butler-core/releases/download/v0.2.0/butler_core-0.2.0-py3-none-any.whl#sha256=40e18d5ef5792c9c5dad807287ae6717e6a0ba0833751503c2ab06c9c2405736",
+    "butler-core @ git+https://github.com/keriol/butler-core.git@827bbac1038b6591f88648e5b69e50ae66834c19",
 ]
 
 [project.scripts]

--- a/tests/test_container_distribution.py
+++ b/tests/test_container_distribution.py
@@ -21,6 +21,21 @@ def test_dockerfile_uses_non_root_runtime() -> None:
     assert "/var/run/docker.sock" not in dockerfile
 
 
+def test_development_line_consumes_independent_hap() -> None:
+    pyproject = read("pyproject.toml")
+    dockerfile = read("Dockerfile")
+
+    assert 'version = "0.2.3.dev0"' in pyproject
+    assert (
+        "827bbac1038b6591f88648e5b69e50ae66834c19"
+        in pyproject
+    )
+    assert "butler-home-assistant" in dockerfile
+    assert "home-assistant-plugin/archive/${HAP_REF}.tar.gz" in dockerfile
+    assert "wilfred-home-assistant @" not in dockerfile
+    assert "ARG HAP_REF=d1856791b887c36e54c71fe3e81646f969249885" in dockerfile
+
+
 def test_compose_keeps_runtime_hardened() -> None:
     compose = read("compose.yaml")
 
@@ -34,7 +49,8 @@ def test_compose_keeps_runtime_hardened() -> None:
         "wilfred_home_assistant.bootstrap:"
         "create_plugin_from_environment"
     ) in compose
-    assert "wilfred:0.2.2" in compose
+    assert "wilfred:0.2.3.dev0" in compose
+    assert "HAP_REF" in compose
 
 
 def test_reference_binding_is_loopback_only() -> None:
@@ -137,3 +153,4 @@ def test_container_ci_verifies_registry_pull() -> None:
     assert "docker image rm" in workflow
     assert "docker pull" in workflow
     assert "verify_runtime.py" in workflow
+    assert "HAP_REF=d1856791b887c36e54c71fe3e81646f969249885" in workflow

--- a/tests/test_development_environment.py
+++ b/tests/test_development_environment.py
@@ -84,16 +84,16 @@ class DevelopmentEnvironmentTests(unittest.TestCase):
         self.assertNotIn("uvicorn", runtime_names)
 
     def test_runtime_dependency_is_butler_core(self) -> None:
-        dependencies = self.load_project()["dependencies"]
+        project = self.load_project()
+        dependencies = project["dependencies"]
 
+        self.assertEqual(project["version"], "0.2.3.dev0")
         self.assertEqual(len(dependencies), 1)
         self.assertEqual(
             dependencies[0],
             "butler-core @ "
-            "https://github.com/keriol/butler-core/"
-            "releases/download/v0.2.0/"
-            "butler_core-0.2.0-py3-none-any.whl"
-            "#sha256=40e18d5ef5792c9c5dad807287ae6717e6a0ba0833751503c2ab06c9c2405736",
+            "https://github.com/keriol/butler-core/archive/"
+            "827bbac1038b6591f88648e5b69e50ae66834c19.tar.gz",
         )
 
     def test_commands_are_documented(self) -> None:

--- a/tests/test_distribution_clean_room.py
+++ b/tests/test_distribution_clean_room.py
@@ -12,6 +12,11 @@ import zipfile
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CORE_REF = "827bbac1038b6591f88648e5b69e50ae66834c19"
+CORE_ARCHIVE = (
+    "https://github.com/keriol/butler-core/archive/"
+    f"{CORE_REF}.tar.gz"
+)
 
 
 def _venv_executable(
@@ -43,11 +48,14 @@ def _run(
 
 class WilfredCleanRoomDistributionTests(unittest.TestCase):
     def test_wheel_runs_as_standalone_distribution(self) -> None:
-        environment = os.environ.copy()
-        environment.pop("PYTHONPATH", None)
-        environment.pop("PYTHONHOME", None)
-        environment["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
-        environment["PIP_NO_INDEX"] = "1"
+        build_environment = os.environ.copy()
+        build_environment.pop("PYTHONPATH", None)
+        build_environment.pop("PYTHONHOME", None)
+        build_environment.pop("PIP_NO_INDEX", None)
+        build_environment["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+
+        offline_environment = build_environment.copy()
+        offline_environment["PIP_NO_INDEX"] = "1"
 
         with tempfile.TemporaryDirectory(
             prefix="wilfred-clean-room-",
@@ -65,13 +73,35 @@ class WilfredCleanRoomDistributionTests(unittest.TestCase):
                     "pip",
                     "wheel",
                     "--no-deps",
+                    "--wheel-dir",
+                    str(wheelhouse),
+                    CORE_ARCHIVE,
+                ],
+                cwd=lab,
+                environment=build_environment,
+            )
+
+            core_wheels = list(
+                wheelhouse.glob("butler_core-*.whl")
+            )
+            self.assertEqual(len(core_wheels), 1)
+            core_wheel = core_wheels[0]
+            self.assertIn("0.2.1.dev0", core_wheel.name)
+
+            _run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "wheel",
+                    "--no-deps",
                     "--no-build-isolation",
                     "--wheel-dir",
                     str(wheelhouse),
                     str(PROJECT_ROOT),
                 ],
                 cwd=lab,
-                environment=environment,
+                environment=build_environment,
             )
 
             wheels = list(
@@ -106,7 +136,7 @@ class WilfredCleanRoomDistributionTests(unittest.TestCase):
                     str(virtualenv),
                 ],
                 cwd=lab,
-                environment=environment,
+                environment=build_environment,
             )
 
             clean_python = _venv_executable(
@@ -125,10 +155,35 @@ class WilfredCleanRoomDistributionTests(unittest.TestCase):
                     "pip",
                     "install",
                     "--no-index",
+                    str(core_wheel),
+                ],
+                cwd=lab,
+                environment=offline_environment,
+            )
+
+            _run(
+                [
+                    str(clean_python),
+                    "-m",
+                    "pip",
+                    "install",
+                    "--no-index",
+                    "--no-deps",
                     str(wheel),
                 ],
                 cwd=lab,
-                environment=environment,
+                environment=offline_environment,
+            )
+
+            _run(
+                [
+                    str(clean_python),
+                    "-m",
+                    "pip",
+                    "check",
+                ],
+                cwd=lab,
+                environment=offline_environment,
             )
 
             script = """
@@ -248,7 +303,7 @@ print(
                     script,
                 ],
                 cwd=lab,
-                environment=environment,
+                environment=offline_environment,
             )
 
             payload = json.loads(
@@ -278,7 +333,7 @@ print(
             entrypoint = _run(
                 [str(clean_wilfred)],
                 cwd=lab,
-                environment=environment,
+                environment=offline_environment,
             )
 
             status = json.loads(
@@ -305,7 +360,7 @@ print(
                     "--help",
                 ],
                 cwd=lab,
-                environment=environment,
+                environment=offline_environment,
             )
 
             self.assertIn(


### PR DESCRIPTION
## Summary

Open Wilfred `0.2.3.dev0` as the next development line and prove consumption of the independent Home Assistant Plugin after HAP-004.

## Changes

- advance Wilfred development metadata from released `0.2.2` to `0.2.3.dev0`;
- adopt the exact Butler Core `0.2.1.dev0` development commit `827bbac1038b6591f88648e5b69e50ae66834c19` in the development dependency baseline;
- update container wiring to install independent distribution `butler-home-assistant` from HAP merge commit `d1856791b887c36e54c71fe3e81646f969249885`;
- preserve compatibility import `wilfred_home_assistant.bootstrap:create_plugin_from_environment`;
- deliberately preserve `WILFRED_HOME_ASSISTANT_*` environment variables as a HAP compatibility-path proof;
- update compose/container CI and distribution tests for the new development baseline;
- keep the immutable Wilfred 0.2.2 BOM and historical release snapshots unchanged.

## Version discipline

This PR does not release Wilfred 0.2.3. A new Core dependency baseline is represented by opening `0.2.3.dev0`; release remains a separate future decision governed by WILF-060 BOM discipline.

## Consumer proof

The container workflow builds and runs Wilfred with HAP as a sibling Core consumer. HAP does not depend on Wilfred.

Refs #108.